### PR TITLE
Fix issues #1 #2 #3 and introduce /ds-designer agent

### DIFF
--- a/skills/ds-add-variant/SKILL.md
+++ b/skills/ds-add-variant/SKILL.md
@@ -13,19 +13,97 @@ Add a variant or state to an existing component in Figma.
 ## Procedure
 
 ### Step 1 — Load context
+Read `design-system/memory/active_session.md` if it exists — pick up component name,
+figma_node, inspection snapshot, confirmed token gaps, and exploration result if already done.
+
+Read `design-system/memory/feedback_*.md` if any exist and apply entries tagged `all` or `ds-add-variant`.
+
 Read:
 - `design-system/knowledge-base/components.md`
 - `design-system/knowledge-base/tokens.md`
 - `design-system/knowledge-base/conventions.md`
+- `design-system/knowledge-base/theming-conventions.md` (alias chain rules, if exists)
 - `design-system/config.md`
 
 ### Step 2 — Identify target
 If not specified, ask:
 1. **Which component?** — search components.md for the name
-2. **What variant/state to add?** — new property value, new boolean state, etc.
+2. **What variant/state to add?** — new property value, new boolean state, visual style change, etc.
 
 Verify the component exists in Figma via `figma_search_components` + `figma_get_component_details`.
 Show the current variant structure.
+
+### Step 2b — Classify the request
+Determine whether this is:
+- **Structural variant** — adding a new property value or boolean state (e.g., "add a destructive variant") → proceed to Step 3
+- **Visual / style change** — changing how the component looks (e.g., "make it 3D", "add shadows", "change the style") → trigger **Exploration Phase** first (Step 2c)
+
+When in doubt, treat as a visual change and run the exploration phase.
+
+### Step 2c — Exploration phase (visual/style changes only)
+Do NOT touch the real component. Build 3–4 concept frames on a separate exploration page:
+
+1. Create a temporary page named `Exploration - <ComponentName>`:
+   ```javascript
+   await figma.loadAllPagesAsync();
+   let explorePage = figma.root.children.find(p => p.name.startsWith('Exploration -'));
+   if (!explorePage) {
+     explorePage = figma.createPage();
+     explorePage.name = 'Exploration - <ComponentName>';
+   }
+   figma.currentPage = explorePage;
+   ```
+
+2. Build 3–4 concept frames with **distinct visual directions**. Each frame must:
+   - Use `primaryAxisSizingMode = 'AUTO'` (never fixed height)
+   - Set all text nodes: `textNode.textAutoResize = 'HEIGHT'` then `textNode.resize(textNode.width, 1)`
+   - Be labeled clearly (e.g., "Concept A — Subtle 3D", "Concept B — High Contrast 3D")
+   - Use placeholder values for tokens (document what tokens it would need)
+
+3. Take a screenshot with `figma_take_screenshot`, present it to the user.
+
+4. Ask: "Which direction do you want to pursue? You can also share a mockup or reference and I'll explore that alongside these."
+
+5. Iterate based on feedback (max 2 rounds). Only proceed when the user explicitly picks a direction.
+
+### Step 2d — Token audit (required before any implementation)
+Before modifying the real component, audit token coverage for the chosen design:
+
+1. List every visual property the change will affect (fills, strokes, effects, radius, spacing, typography)
+2. For each property, check `design-system/knowledge-base/tokens.md`:
+   - **Covered** — a token exists and will be used as a variable binding
+   - **Gap** — no token exists; note what needs to be created
+3. Check `design-system/knowledge-base/theming-conventions.md` (if it exists) for alias rules
+4. Present the gap list:
+   ```
+   ## Token Audit
+
+   **Covered:** <list of tokens that will be bound>
+
+   **Gaps (need to create):**
+   - <property>: needs a primitive in `<collection>` → alias in `<semantic-collection>`
+   ```
+5. Wait for user confirmation before creating any missing tokens.
+
+### Step 2e — Inspect current state (required before modifying strokes/effects)
+Before touching any existing component node, read and document its current state:
+
+```javascript
+const node = figma.currentPage.findOne(n => n.name === '<ComponentName>');
+const state = {
+  fills: node.fills,
+  strokes: node.strokes,
+  strokeStyleId: node.strokeStyleId,
+  effects: node.effects,
+  effectStyleId: node.effectStyleId,
+  // ... other relevant properties
+};
+return JSON.stringify(state);
+```
+
+Note:
+- If a **gradient stroke** exists (`fills[i].type === 'GRADIENT_LINEAR'` or similar) → preserve it as a named paint style before any modification
+- If **effect styles** are bound (`effectStyleId !== ''`) → document the style name before overwriting
 
 ### Step 3 — Plan the change
 Present what will happen:
@@ -75,3 +153,7 @@ Invoke write-memory:
 - Never modify the component without confirmation
 - The new variant must follow the same token bindings and conventions as existing variants
 - Always screenshot the result
+- **Never apply raw hex values** — all fills, strokes, and colors must be variable bindings. If a token doesn't exist, surface the gap and wait for confirmation before creating it.
+- **Always use async style setters** — `strokeStyleId =` and `effectStyleId =` throw on dynamic-page documents. Use `await node.setStrokeStyleIdAsync(id)` and `await node.setEffectStyleIdAsync(id)` instead.
+- **Inspect before modifying** — read and document existing strokes, effects, and fills before any change. Preserve gradient strokes and named effect styles — do not silently overwrite them.
+- **Run exploration phase for all visual/style changes** — do not jump to implementation for any request that changes the look of a component. Build concept frames first, get user sign-off, then implement.

--- a/skills/ds-build/SKILL.md
+++ b/skills/ds-build/SKILL.md
@@ -14,6 +14,9 @@ Construct a component in Figma from a build spec.
 ## Procedure
 
 ### Step 1 — Load or create build spec
+Read `design-system/memory/active_session.md` if it exists — pick up component name,
+figma_node, confirmed token gaps, and any steps_remaining from an in-progress session.
+
 Check if a build spec exists in `design-system/memory/specs/`:
 - If YES → load it, confirm it's still the plan
 - If NO → ask the user: "No build spec found. Want to run `/ds-plan` first, or
@@ -23,6 +26,7 @@ Check if a build spec exists in `design-system/memory/specs/`:
 Also load:
 - `design-system/knowledge-base/components.md`
 - `design-system/knowledge-base/tokens.md`
+- `design-system/knowledge-base/theming-conventions.md` (alias chain rules, if exists)
 - `design-system/config.md`
 - Any relevant `design-system/memory/feedback_*.md`
 
@@ -65,13 +69,22 @@ If the spec defines variants:
 3. Modify each duplicate per the spec
 4. Combine into a component set
 
-### Step 6 — Bind tokens
-For all visual properties:
-1. Look up the token in knowledge-base/tokens.md
-2. Find the corresponding Figma variable
-3. Bind with `setBoundVariable`
+### Step 6 — Token audit and bind
+Before binding, run a token audit:
+1. List every visual property that needs a token (fills, strokes, effects, radius, spacing, typography)
+2. Check `design-system/knowledge-base/tokens.md` for each — mark as **covered** or **gap**
+3. Check `design-system/knowledge-base/theming-conventions.md` (if it exists) for alias rules
+4. Present gaps and wait for confirmation before creating missing tokens
 
-For properties without variable bindings, set the value directly and note it.
+Then bind all covered tokens:
+- Look up the token in knowledge-base/tokens.md
+- Find the corresponding Figma variable
+- Bind with `setBoundVariable`
+- **Never set raw hex/RGBA values** on semantic variables — surface a gap instead
+
+For style bindings use async setters:
+- `await node.setStrokeStyleIdAsync(id)` — never `node.strokeStyleId =`
+- `await node.setEffectStyleIdAsync(id)` — never `node.effectStyleId =`
 
 ### Step 7 — Screenshot and verify
 Take a screenshot with `figma_take_screenshot`.
@@ -92,6 +105,14 @@ Invoke write-memory:
 ### Step 10 — Report
 Present to user:
 ```
+✦  ╲  ▄███████████▄  ╱  ✦
+    █  ★       ★  █
+    █      ◡      █
+     ▀███████████▀
+        ▄█████▄
+
+  Yay! another component built  ✦
+
 ## Build Complete: <ComponentName>
 
 - Variants: <count>
@@ -110,3 +131,6 @@ Component is in <page> > <section>.
 - If a needed component doesn't exist, do NOT build it inline — flag it and continue
 - Follow feedback files for build preferences (e.g., screenshot frequency)
 - If context is above 50% used → recommend `/clear` before next workflow
+- **Never apply raw hex/RGBA values** — all visual properties must be token/variable bindings. Surface gaps, wait for confirmation.
+- **Always use async style setters** — `await node.setStrokeStyleIdAsync(id)` and `await node.setEffectStyleIdAsync(id)` instead of direct assignment.
+- **Text nodes in exploration or concept frames** must set `textAutoResize = 'HEIGHT'` and `node.resize(node.width, 1)`. Parent frames must use `primaryAxisSizingMode = 'AUTO'`.

--- a/skills/ds-designer/SKILL.md
+++ b/skills/ds-designer/SKILL.md
@@ -1,0 +1,344 @@
+---
+name: ds-designer
+description: >
+  Main design agent for all component and theme work. Triggered by /ds-designer,
+  or natural language such as: "work on [component]", "build a [component]",
+  "I need a [component]", "create a [component]", "make the [component] look [adjective]",
+  "restyle the [component]", "redesign the [component]", "update the [component]",
+  "make it [adjective]", "add a [state] to [component]", "add a [variant]",
+  "extend the [component]", "change the theme", "apply a new theme",
+  "change the brand color", "add dark mode", "add light mode",
+  "the [component] needs [change]", "I want to change how [component] looks",
+  "can you build", "can you create", "let's work on".
+  Do NOT trigger for /ds-init, /ds-update, /ds-audit, /ds-handoff, /ds-doc, /ds-help.
+---
+
+# ds-designer — Design Agent
+
+Unified agent for all component building, component editing, and theme work.
+
+---
+
+## Step 1 — Load context and check for in-progress session
+
+Read these files (all optional — skip gracefully if missing):
+- `design-system/memory/active_session.md` — in-progress session checkpoint
+- `design-system/knowledge-base/theming-conventions.md` — alias chain rules
+- `design-system/knowledge-base/components.md` — component registry
+- `design-system/knowledge-base/tokens.md` — token library
+- `design-system/config.md` — file key, UI kit, tracker
+- `design-system/memory/feedback_*.md` — apply entries tagged `all` or `ds-designer`
+
+**If `active_session.md` exists and has `status: in_progress`:**
+
+Present a recovery prompt using AskUserQuestion:
+```
+question: "Found an in-progress session: [type] on [component/scope]. Resume where you left off?"
+options:
+  - "Resume — pick up from [last completed phase]"
+  - "Start fresh — discard previous session"
+```
+
+On "Resume" → skip to the phase after the last completed one, using saved context from the file.
+On "Start fresh" → overwrite `active_session.md` and proceed from Step 2.
+
+---
+
+## Step 2 — Infer intent
+
+Try to classify from the user's words before asking anything.
+
+| Signal words | Intent |
+|---|---|
+| "build", "create", "new", "I need a", "make me a" + component noun | **A — New component** |
+| "make it look", "restyle", "redesign", "change the style", "make [adj]", "[adj]-ify", "3D", "elevated" | **B — Visual / style change** |
+| "add a [state]", "add [variant]", "add hover", "add disabled", "extend", "add an option" | **C — Structural variant** |
+| "theme", "brand color", "dark mode", "light mode", "apply a theme", "change color", "new mode" | **D — Theme change** |
+| "edit", "update", "change", "work on", "fix" (no clear style/structural signal) | **→ Ask** |
+
+**If ambiguous**, use AskUserQuestion:
+```
+question: "What kind of change is this?"
+options:
+  - "Build a new component from scratch"
+  - "Edit the visual style of an existing component"
+  - "Add a new variant or state to an existing component"
+  - "Change theme tokens or brand colors"
+```
+
+Write initial checkpoint immediately after classification:
+```markdown
+# Active Session
+type: [A|B|C|D]
+component: [name or "system-wide"]
+figma_node: [id if known, else "pending"]
+figma_page: [page name if known]
+scope: [component | system-wide]
+status: in_progress
+session_started: [date]
+
+## Phases
+```
+
+---
+
+## Branch A — New Component
+
+### A1 — Planning interview
+Ask (skip any already answered in the user's request):
+1. **Name** — what is this component called?
+2. **Purpose** — one sentence: what does it do?
+3. **Variants** — any known states or modes? (e.g., size, type, state)
+4. **Children** — does it contain other components? Which ones?
+5. **Reference** — any Figma link, screenshot, or existing component to base it on?
+
+Write spec to `design-system/memory/specs/<ComponentName>.md`. Confirm before proceeding.
+
+**Checkpoint:** append to active_session.md:
+```markdown
+### A1: planning
+status: complete
+component: <name>
+spec_file: design-system/memory/specs/<name>.md
+```
+
+### A2 — Token audit
+List every visual property (fills, strokes, effects, radius, spacing, typography).
+For each: check `tokens.md` → **covered** or **gap**.
+If `theming-conventions.md` exists: enforce alias rules on any gaps.
+
+Present gap list and wait for confirmation before creating tokens.
+
+**Checkpoint:** append phase block with `status: complete` and `gaps_confirmed: [list]`.
+
+### A3 — Find or create container
+```javascript
+await figma.loadAllPagesAsync();
+let page = figma.root.children.find(p => p.name === '<target page>');
+figma.currentPage = page;
+let section = page.findOne(n => n.type === 'SECTION' && n.name === '<section>');
+if (!section) { section = figma.createSection(); section.name = '<section>'; }
+```
+
+### A4 — Build
+Construct the component following the spec:
+- Create outer frame with auto-layout
+- Add children (instantiate existing components, create text nodes, create sub-frames)
+- Bind all visual properties as variable references via `setBoundVariable`
+- **Never set raw hex/RGBA values** — use variable bindings only
+- Use `await node.setStrokeStyleIdAsync(id)` and `await node.setEffectStyleIdAsync(id)`
+- Set up variants if defined: build default → duplicate per variant → combine into component set
+
+**Checkpoint:** append `A4: build` with `status: in_progress` and `steps_remaining` list. Check each step off as done.
+
+### A5 — Screenshot and verify
+`figma_take_screenshot` → analyze alignment, spacing, proportions.
+Fix issues, re-screenshot (max 3 iterations).
+Invoke validate-component checklist.
+
+### A6 — Write back and report
+- Update `design-system/knowledge-base/components.md`
+- Invoke write-memory → REGISTRY.md (status: built), MEMORY.md counts
+- Set `active_session.md` status to `complete`
+
+Report:
+```
+✦  Build Complete: <ComponentName>
+- Variants: <N>
+- Token bindings: <N>
+- Gaps created: <N>
+- Validation: <pass/fail>
+```
+
+---
+
+## Branch B — Visual / Style Change
+
+### B1 — Identify target
+If not specified, ask which component. Verify in Figma via `figma_search_components`.
+Store `figma_node` and `figma_page` in active_session.md immediately.
+
+**Checkpoint:** append `B1: identify` with node ID and page.
+
+### B2 — Inspect current state
+Before touching anything, read the component's current visual state:
+```javascript
+const node = await figma.getNodeByIdAsync('<node_id>');
+const state = {
+  fills: node.fills,
+  strokes: node.strokes,
+  strokeStyleId: node.strokeStyleId,
+  effects: node.effects,
+  effectStyleId: node.effectStyleId,
+  boundVariables: node.boundVariables,
+};
+return JSON.stringify(state);
+```
+Document any gradient strokes or bound effect styles — these must be preserved.
+
+**Checkpoint:** append `B2: inspect` with serialized current state.
+
+### B3 — Exploration phase
+Create a temporary exploration page — do NOT touch the real component:
+```javascript
+await figma.loadAllPagesAsync();
+let explorePage = figma.root.children.find(p => p.name === 'Exploration - <ComponentName>');
+if (!explorePage) {
+  explorePage = figma.createPage();
+  explorePage.name = 'Exploration - <ComponentName>';
+}
+figma.currentPage = explorePage;
+```
+
+Build 3–4 concept frames with distinct visual directions. Each frame:
+- `primaryAxisSizingMode = 'AUTO'` — never fixed height
+- All text nodes: `textNode.textAutoResize = 'HEIGHT'` then `textNode.resize(textNode.width, 1)`
+- Clearly labeled: "Concept A — Subtle", "Concept B — Bold", etc.
+
+`figma_take_screenshot` → present to user.
+
+Use AskUserQuestion:
+```
+question: "Which direction do you want to pursue?"
+options:
+  - "Concept A — [description]"
+  - "Concept B — [description]"
+  - "Concept C — [description]"
+  - "Concept D — [description]"
+  - "Show me a variation on one of these"
+  - "I'll share a reference instead"
+```
+
+Iterate on feedback (max 2 rounds). Wait for explicit pick before proceeding.
+
+**Checkpoint:** append `B3: exploration` with `status: complete`, `chosen_concept`, and description of direction.
+
+### B4 — Token audit
+Same as A2. List property gaps, check alias rules, present and confirm.
+
+**Checkpoint:** append `B4: token_audit` with gaps confirmed.
+
+### B5 — Implement
+Apply the chosen direction to the real component:
+- All fills and strokes via variable bindings only
+- Preserve gradient strokes unless user explicitly said to replace them
+- `await node.setStrokeStyleIdAsync(id)` and `await node.setEffectStyleIdAsync(id)`
+- Screenshot and verify after each significant change
+
+**Checkpoint:** `B5: implementation` with steps_remaining, checked off as done.
+
+### B6 — Write back
+Update knowledge-base, invoke write-memory, set session `status: complete`.
+
+---
+
+## Branch C — Structural Variant
+
+### C1 — Identify target and new variant
+Ask which component and what to add (new property value, new boolean state, etc.).
+Verify in Figma. Show current variant structure.
+
+**Checkpoint:** `C1: identify` with node ID, current variants, and what's being added.
+
+### C2 — Inspect current state
+Same inspection as B2. Preserve existing strokes and effects.
+
+### C3 — Token audit
+Audit token coverage for the new variant's visual properties. Same gap flow as A2.
+
+### C4 — Build the variant
+1. Duplicate an appropriate existing variant
+2. Rename per conventions
+3. Update visual properties with variable bindings only
+4. Add to component set
+5. `figma_take_screenshot` — check consistency with existing variants
+
+**Checkpoint:** `C4: build` with status and steps.
+
+### C5 — Write back
+Update `components.md`, invoke write-memory, set session `status: complete`.
+
+---
+
+## Branch D — Theme Change
+
+### D1 — Load alias chain rules
+Read `design-system/knowledge-base/theming-conventions.md`.
+
+If the file doesn't exist → run alias detection inline:
+```javascript
+const collections = await figma.variables.getLocalVariableCollectionsAsync();
+const vars = await figma.variables.getLocalVariablesAsync();
+// Sample semantic variables, check value types for VARIABLE_ALIAS
+```
+Document the alias chain and write `theming-conventions.md` before proceeding.
+
+**Enforce always:** semantic variables are alias pointers — never raw RGBA/hex values.
+
+### D2 — Identify scope and intent
+Ask (or infer):
+- **Scope:** system-wide color change? A specific semantic token? A new mode?
+- **Target mode:** which mode is the customization target? (brand mode — never reference modes)
+- **What's changing:** new primitive value? New semantic alias? Entirely new mode?
+
+Write initial session:
+```markdown
+scope: system-wide | targeted
+target_mode: <mode name>
+change_type: primitive | alias | new_mode
+```
+
+### D3 — Plan changes
+Present the full change plan before touching anything:
+```
+## Theme Change Plan
+
+**Adding primitives:**
+- raw colors / Brand/new-blue = #0055FF
+
+**Updating aliases (brand mode only):**
+- color/background/brand → raw colors / Brand/new-blue
+
+**NOT touching (reference modes — read only):**
+- shadcn mode, shadcn-dark mode
+```
+
+Use AskUserQuestion:
+```
+question: "Ready to apply these changes?"
+options:
+  - "Yes, apply"
+  - "Adjust the plan first"
+```
+
+**Checkpoint:** `D3: plan` with full change list.
+
+### D4 — Execute
+For each change:
+1. Add primitive to the primitive collection with the correct raw value
+2. Update the semantic variable in the **brand/mutable mode only** as a `VARIABLE_ALIAS` reference
+3. **Never** write raw RGBA on a semantic variable
+4. **Never** modify reference/read-only modes
+
+**Checkpoint:** `D4: execution` with steps_remaining, checked off as done.
+
+### D5 — Validate
+Take a screenshot of affected components to verify the theme change propagated correctly.
+Check that no semantic variables have raw values (spot-check 5–10).
+
+### D6 — Write back
+Update `tokens.md` and `theming-conventions.md` if mode structure changed.
+Invoke write-memory. Set session `status: complete`.
+
+---
+
+## Global Rules
+
+- **Never apply raw hex/RGBA** — all fills, strokes, colors must be variable bindings. Surface gaps, wait for confirmation before creating tokens.
+- **Always use async style setters** — `setStrokeStyleIdAsync()`, `setEffectStyleIdAsync()`.
+- **Inspect before modifying** — read and preserve existing strokes, effects, gradient fills.
+- **Exploration before implementation** — any visual style change (Branch B) requires concept exploration and explicit user sign-off before touching real components.
+- **Write checkpoint after every phase** — append the phase block to `active_session.md` immediately on completion.
+- **Never place components on blank canvas** — always inside a Section or Frame.
+- **If context is above 60% used** → warn the user: "Context is getting full. I've checkpointed progress. Consider `/clear` and then continue — I'll resume from where we left off."
+- **On session complete** → set `active_session.md` status to `complete`. Do not delete — keep for reference.

--- a/skills/ds-init/SKILL.md
+++ b/skills/ds-init/SKILL.md
@@ -13,13 +13,16 @@ Scan a Figma file to discover its design system and populate the knowledge-base.
 
 ## Procedure
 
-### Step 1 — Check if already initialized
+### Step 1 — Load feedback
+Read `design-system/memory/feedback_*.md` if any exist. Apply entries tagged `all` or `ds-init` throughout this workflow.
+
+### Step 2 — Check if already initialized
 Read `design-system/knowledge-base/components.md`.
 - If it contains component entries (not just the template header) → warn user that
   re-running will overwrite. Ask to confirm or suggest `/ds-update` instead.
 - If empty/template only → proceed.
 
-### Step 2 — Ask basics
+### Step 3 — Ask basics
 
 Ask the user (skip any already answered):
 1. **Figma file URL** (required) — extract fileKey from the URL
@@ -27,7 +30,7 @@ Ask the user (skip any already answered):
 3. **Ticket tracker** — "Do you use a ticket tracker for handoff?" (Jira, Linear, none)
    - If Jira/Linear: ask for project key/ID
 
-### Step 3 — Scan tokens
+### Step 4 — Scan tokens
 Call `figma_get_variables` to retrieve all variable collections.
 
 Organize into `design-system/knowledge-base/tokens.md`:
@@ -55,7 +58,7 @@ For single-mode collections:
 | <name> | <value> |
 ```
 
-### Step 4 — Scan components
+### Step 5 — Scan components
 Call `figma_search_components` to get all components.
 For each component (or a representative sample if >50), call `figma_get_component_details`
 to get variants, properties, and children.
@@ -78,14 +81,45 @@ Format:
 - **Source**: <ui-kit-name|custom>
 ```
 
-### Step 5 — Scan styles
+### Step 6 — Scan styles
 Call `figma_get_styles` to get text styles, color styles, and effect styles.
+
+If `figma_get_styles` fails or returns zero styles (possible on dynamic-page documents where the sync API throws), fall back to `figma_execute` with async code:
+```javascript
+const [textStyles, paintStyles, effectStyles] = await Promise.all([
+  figma.getLocalTextStylesAsync(),
+  figma.getLocalPaintStylesAsync(),
+  figma.getLocalEffectStylesAsync(),
+]);
+return JSON.stringify({
+  text: textStyles.map(s => ({ id: s.id, name: s.name, fontSize: s.fontSize, fontFamily: s.fontName?.family, fontWeight: s.fontName?.style })),
+  paint: paintStyles.map(s => ({ id: s.id, name: s.name })),
+  effect: effectStyles.map(s => ({ id: s.id, name: s.name, effects: s.effects })),
+});
+```
 
 Organize into `design-system/knowledge-base/styles.md`:
 - Separate sections for text, color, and effect styles
 - Table format per the schema in the design spec
 
-### Step 6 — Infer conventions
+### Step 6b — Read documentation page
+Before inferring conventions, check if the Figma file has a documentation or about page:
+
+```javascript
+await figma.loadAllPagesAsync();
+const docPage = figma.root.children.find(p =>
+  /about|documentation|docs|readme|📖|guide/i.test(p.name)
+);
+if (docPage) {
+  const textNodes = docPage.findAllWithCriteria({ types: ['TEXT'] });
+  return JSON.stringify(textNodes.map(n => ({ name: n.name, chars: n.characters?.slice(0, 2000) })));
+}
+return null;
+```
+
+If a documentation page exists, extract its theming/token sections and include them verbatim in the output below.
+
+### Step 7 — Infer conventions
 Analyze the scanned data for patterns:
 
 **Naming patterns** — look at component names, token names, style names:
@@ -102,6 +136,13 @@ Analyze the scanned data for patterns:
 - Category prefixes? (color-, spacing-, etc.)
 - Scale patterns? (1, 2, 3 or sm, md, lg)
 
+**Alias architecture** — inspect token values from `figma_get_variables`:
+- Sample semantic/alias-named variables (those named with semantic terms like `color/background`, `text/primary`, etc.)
+- Check their value type: is it `VARIABLE_ALIAS` (pointer to another variable) or a raw RGBA/float?
+- If semantic variables are `VARIABLE_ALIAS` type → this is an **alias chain architecture**. Document it as a hard constraint.
+- Identify which collections are primitives (raw values) vs. semantics (aliases)
+- For each mode in the semantic collection: classify as `brand` (mutable, user customizes) or `reference` (read-only, do not modify) based on the mode name (e.g., `your_brand` = brand, `shadcn`/`shadcn-dark` = reference)
+
 For each inferred convention:
 - Assign confidence: **high** (>80% consistent), **medium** (50-80%), **low** (<50%)
 - Low-confidence: present the raw data and ask the user to define the convention
@@ -109,7 +150,41 @@ For each inferred convention:
 
 Write to `design-system/knowledge-base/conventions.md`.
 
-### Step 7 — Generate framework.md
+### Step 7b — Write theming conventions
+If an alias chain architecture was detected (semantic variables are `VARIABLE_ALIAS`), write `design-system/knowledge-base/theming-conventions.md`:
+
+```markdown
+# Theming Conventions
+
+## Token Architecture
+Semantic variables are VARIABLE_ALIAS pointers — they reference primitives, never hold raw hex/RGBA values.
+
+<primitive-collection> (raw values)
+    ↓ referenced by
+<semantic-collection> (alias pointers, N modes)
+    ↓ consumed by
+components
+
+## Hard Rules
+- **NEVER** set a raw RGBA/hex value on a semantic variable — it breaks the alias chain
+- **ALWAYS** set semantic variable values as VARIABLE_ALIAS references to primitives
+- To introduce a new color: add it to `<primitive-collection>` first, then alias the semantic to it
+
+## Theming Workflow
+1. Add a new primitive to `<primitive-collection>` (e.g. `Brand/primary = #0D99FF`)
+2. In the target mode of `<semantic-collection>`, update the semantic variable to alias that primitive
+3. Never write raw values onto semantic variables
+
+## Modes
+| Mode | Collection | Type | Rule |
+|------|-----------|------|------|
+<one row per mode, classified as brand/reference>
+
+## Notes from documentation page
+<paste relevant sections from the Figma documentation page if found, or "No documentation page found">
+```
+
+### Step 8 — Generate framework.md
 Write `design-system/framework.md` with:
 - System overview (UI kit, counts)
 - Component organization (how grouped in Figma)
@@ -117,15 +192,23 @@ Write `design-system/framework.md` with:
 - Composition patterns (detected nesting)
 - File references (file key, URL)
 
-### Step 8 — Initialize memory
+### Step 9 — Initialize memory
 - Populate `design-system/memory/REGISTRY.md` with all discovered components (status: "scanned")
 - Write `design-system/config.md` with project details
 - Update `design-system/MEMORY.md` dashboard with counts
 
-### Step 9 — Present summary
+### Step 10 — Present summary
 
 Show the user:
 ```
+   ▄███████████▄  ✦
+  █  ◕       ◕  █
+  █      ‿      █
+   ▀███████████▀
+  ╱   ▄█████▄   ╲
+
+  I now have all your design system sauce  ✦
+
 ## Scan Complete
 
 **UI Kit:** <name>

--- a/skills/ds-token/SKILL.md
+++ b/skills/ds-token/SKILL.md
@@ -13,15 +13,20 @@ Find the right token for a design intent.
 
 ## Procedure
 
-### Step 1 — Understand the need
+### Step 1 — Load context
+Read `design-system/memory/active_session.md` if it exists — apply any token gaps already confirmed in the current session to avoid re-asking.
+Read `design-system/knowledge-base/theming-conventions.md` if it exists — apply alias chain rules.
+Read `design-system/memory/feedback_*.md` if any exist and apply entries tagged `all` or `ds-token`.
+
+### Step 2 — Understand the need
 If the user hasn't specified clearly, ask:
 - What is the design intent? (e.g., "background for a card", "spacing between form fields")
 - What context? (e.g., which component, which state)
 
-### Step 2 — Invoke resolve-token
+### Step 3 — Invoke resolve-token
 Call the resolve-token internal skill with the design intent.
 
-### Step 3 — Present result
+### Step 4 — Present result
 
 **If high confidence match:**
 > Token: `<token-name>` — <value>
@@ -41,7 +46,7 @@ Call the resolve-token internal skill with the design intent.
 >
 > Once you add this token to the system, run `/ds-update` to refresh.
 
-### Step 4 — Write back
+### Step 5 — Write back
 Invoke write-memory if any gaps were logged.
 
 ## Rules

--- a/skills/ds-update/SKILL.md
+++ b/skills/ds-update/SKILL.md
@@ -13,6 +13,8 @@ Re-scan the Figma file and show what changed since the last scan.
 ## Procedure
 
 ### Step 1 — Load current state
+Read `design-system/memory/feedback_*.md` if any exist and apply entries tagged `all` or `ds-update`.
+
 Read:
 - `design-system/config.md` — get Figma file key and agent version
 - `design-system/knowledge-base/tokens.md` — current token state
@@ -31,6 +33,20 @@ Run the same scans as ds-init:
 - `figma_get_variables` → new token state
 - `figma_search_components` + `figma_get_component_details` → new component state
 - `figma_get_styles` → new style state
+
+  If `figma_get_styles` returns zero styles (sync API throws on dynamic-page documents), fall back to `figma_execute`:
+  ```javascript
+  const [textStyles, paintStyles, effectStyles] = await Promise.all([
+    figma.getLocalTextStylesAsync(),
+    figma.getLocalPaintStylesAsync(),
+    figma.getLocalEffectStylesAsync(),
+  ]);
+  return JSON.stringify({
+    text: textStyles.map(s => ({ id: s.id, name: s.name, fontSize: s.fontSize, fontFamily: s.fontName?.family, fontWeight: s.fontName?.style })),
+    paint: paintStyles.map(s => ({ id: s.id, name: s.name })),
+    effect: effectStyles.map(s => ({ id: s.id, name: s.name, effects: s.effects })),
+  });
+  ```
 
 ### Step 4 — Compute semantic diff
 Compare old vs. new state for each knowledge-base file:


### PR DESCRIPTION
## Summary

- **Fixes #1** — Styles silently dropped on dynamic-page Figma documents (sync API bug)
- **Fixes #2** — `ds-init` now detects alias chain architecture, classifies modes, and writes `theming-conventions.md`
- **Fixes #3** — Explore-first protocol, inspect-before-modify, mandatory token audit, async style setters
- **New** — `/ds-designer` unified agent for all component and theme work

## Changes

### Bug fixes

| Skill | Fix |
|---|---|
| `ds-init` Step 6 | Falls back to `getLocalTextStylesAsync/getLocalPaintStylesAsync/getLocalEffectStylesAsync` when `figma_get_styles` returns zero results |
| `ds-update` Step 3 | Same async fallback |
| `ds-init` Step 6b | Reads Figma documentation/about pages and extracts theming instructions |
| `ds-init` Step 7 | Detects `VARIABLE_ALIAS` type on semantic tokens; classifies modes as brand (mutable) vs reference (read-only) |
| `ds-init` Step 7b | Writes `knowledge-base/theming-conventions.md` with alias chain, mode table, theming workflow, and hard no-raw-hex rule |
| `ds-add-variant` Step 2b | Classifies visual vs structural intent before any implementation |
| `ds-add-variant` Step 2c | Exploration phase with correct `textAutoResize = 'HEIGHT'` and `primaryAxisSizingMode = 'AUTO'` — fixes fixed-height text bug |
| `ds-add-variant` Step 2d | Mandatory token audit before implementation |
| `ds-add-variant` Step 2e | Inspect-before-modify — reads current strokes/effects, preserves gradient strokes and bound effect styles |
| `ds-add-variant` + `ds-build` Rules | Always use `setStrokeStyleIdAsync` / `setEffectStyleIdAsync`; never apply raw hex |
| `ds-build` Step 6 | Token audit before binding; async style setters required |
| `ds-token` Step 1 | Reads `active_session.md` and `theming-conventions.md` at startup |

### New: `/ds-designer` agent (`skills/ds-designer/SKILL.md`)

A unified agent that handles all component and theme work:

- **Natural language triggers** — fires on ~20 phrase patterns without needing the slash command ("make the button look", "I need a", "add dark mode", "restyle the", etc.)
- **`AskUserQuestion` widget** — one question, four options for ambiguous intent; infers from verb when obvious
- **Four branches:**
  - A — New component (spec → token audit → build → verify)
  - B — Visual / style change (inspect → explore concepts → token audit → implement)
  - C — Structural variant (inspect → token audit → add variant)
  - D — Theme change (alias-chain enforcement, mutable mode only, never raw hex)
- **`active_session.md` checkpoint ledger** — written after every phase; survives `/clear` and context compression with full resume flow
- **60% context warning** with automatic resume promise
- `ds-build`, `ds-add-variant`, `ds-token` all read `active_session.md` at Step 1 for context continuity on direct invocations

## Test plan

- [ ] Run `/ds-init` on a dynamic-page Figma document — verify styles are captured
- [ ] Run `/ds-init` on a shadcn-based file with alias chain — verify `theming-conventions.md` is written with correct mode classification
- [ ] Ask "make the button look 3D" — verify exploration phase fires before any real component is touched
- [ ] Ask "add a destructive variant" — verify it skips exploration and goes straight to structural variant flow
- [ ] Ask "change the brand color" — verify Branch D fires, alias chain is respected, no raw hex written
- [ ] Trigger `/clear` mid-exploration — verify `/ds-designer` resumes from checkpoint on next invocation
- [ ] Call `/ds-build` directly — verify it reads `active_session.md` and picks up prior session context
