### PR TITLE
fix: move product design projects folder to repo root

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,11 +35,12 @@ else
   rm -f "$DS_DIR/claude-md-section.md"
 fi
 
-# Scaffold projects/ directory (safe to run on updates — never overwrites existing projects)
-if [ ! -d "$DS_DIR/projects" ]; then
-  mkdir -p "$DS_DIR/projects"
-  cp "$SCRIPT_DIR/templates/projects/PROJECTS.md" "$DS_DIR/projects/PROJECTS.md"
-  echo "  Created design-system/projects/"
+# Scaffold projects/ directory at repo root (safe to run on updates — never overwrites existing projects)
+PROJECTS_DIR="$PROJECT_PATH/projects"
+if [ ! -d "$PROJECTS_DIR" ]; then
+  mkdir -p "$PROJECTS_DIR"
+  cp "$SCRIPT_DIR/templates/projects/PROJECTS.md" "$PROJECTS_DIR/PROJECTS.md"
+  echo "  Created projects/"
 fi
 
 # Always stamp agent_version (runs on fresh install and updates)

--- a/skills/pd-annotate/SKILL.md
+++ b/skills/pd-annotate/SKILL.md
@@ -16,9 +16,9 @@ Add logic and behavior annotations to final designed screens. One annotation fra
 ## Step 1 — Load context
 
 Read:
-- `design-system/projects/<slug>/brief.md` — annotation preference (native or custom), if already set
-- `design-system/projects/<slug>/screen-inventory.md` — screens with status `designed`
-- `design-system/projects/<slug>/active_session.md`
+- `projects/<slug>/brief.md` — annotation preference (native or custom), if already set
+- `projects/<slug>/screen-inventory.md` — screens with status `designed`
+- `projects/<slug>/active_session.md`
 - `design-system/knowledge-base/components.md` — check if annotation component exists
 
 Update `active_session.md`:

--- a/skills/pd-concept/SKILL.md
+++ b/skills/pd-concept/SKILL.md
@@ -17,10 +17,10 @@ Explore design directions: 3 written concepts per item → user picks one → lo
 ## Step 1 — Load context
 
 Read:
-- `design-system/projects/<slug>/brief.md`
-- `design-system/projects/<slug>/flows.md`
-- `design-system/projects/<slug>/directions.md`
-- `design-system/projects/<slug>/active_session.md` — check for concept queue and last completed item
+- `projects/<slug>/brief.md`
+- `projects/<slug>/flows.md`
+- `projects/<slug>/directions.md`
+- `projects/<slug>/active_session.md` — check for concept queue and last completed item
 - `design-system/knowledge-base/components.md` — available components for reference
 - `design-system/knowledge-base/tokens.md` — tokens for lo-fi reference
 
@@ -159,7 +159,7 @@ If "Lock" → proceed to 3g.
 
 ### 3g — Lock direction and log
 
-Update `design-system/projects/<slug>/directions.md`:
+Update `projects/<slug>/directions.md`:
 ```
 | <Item> | Concept 1: <name>, Concept 2: <name>, Concept 3: <name> | <Chosen concept name> | <One line rationale> | <date> |
 ```

--- a/skills/pd-define/SKILL.md
+++ b/skills/pd-define/SKILL.md
@@ -16,9 +16,9 @@ Map user flows, information architecture, and build the screen inventory. The co
 ## Step 1 — Load context
 
 Read:
-- `design-system/projects/<slug>/brief.md`
-- `design-system/projects/<slug>/research.md` (if it exists)
-- `design-system/projects/<slug>/active_session.md`
+- `projects/<slug>/brief.md`
+- `projects/<slug>/research.md` (if it exists)
+- `projects/<slug>/active_session.md`
 
 If no active project → prompt to run `/pd:new-project`.
 
@@ -146,7 +146,7 @@ Save confirmed queue to `active_session.md`.
 
 ## Step 7 — Write flows.md and update screen-inventory.md
 
-**`design-system/projects/<slug>/flows.md`:**
+**`projects/<slug>/flows.md`:**
 ```markdown
 # Flows: <Project Name>
 

--- a/skills/pd-design/SKILL.md
+++ b/skills/pd-design/SKILL.md
@@ -16,12 +16,12 @@ Build final high-fidelity screens using the design system. The second diamond of
 ## Step 1 — Load context
 
 Read:
-- `design-system/projects/<slug>/brief.md`
-- `design-system/projects/<slug>/flows.md`
-- `design-system/projects/<slug>/directions.md` — locked directions per screen
-- `design-system/projects/<slug>/screen-inventory.md` — screens and their status
-- `design-system/projects/<slug>/component-gaps.md` — known gaps
-- `design-system/projects/<slug>/active_session.md`
+- `projects/<slug>/brief.md`
+- `projects/<slug>/flows.md`
+- `projects/<slug>/directions.md` — locked directions per screen
+- `projects/<slug>/screen-inventory.md` — screens and their status
+- `projects/<slug>/component-gaps.md` — known gaps
+- `projects/<slug>/active_session.md`
 - `design-system/knowledge-base/components.md`
 - `design-system/knowledge-base/tokens.md`
 - `design-system/knowledge-base/theming-conventions.md` (if exists)

--- a/skills/pd-discover/SKILL.md
+++ b/skills/pd-discover/SKILL.md
@@ -16,9 +16,9 @@ Research, ideation, and problem framing. The first diamond of Double Diamond.
 ## Step 1 — Load context
 
 Read:
-- `design-system/projects/<slug>/brief.md` — project brief
-- `design-system/projects/<slug>/active_session.md` — current phase and checkpoint
-- `design-system/projects/PROJECTS.md` — identify active project slug
+- `projects/<slug>/brief.md` — project brief
+- `projects/<slug>/active_session.md` — current phase and checkpoint
+- `projects/PROJECTS.md` — identify active project slug
 
 If no active project is found, tell the user:
 > "No active project found. Run `/pd:new-project` to start one."
@@ -98,7 +98,7 @@ If yes → ask for principles or suggest based on the challenge (e.g., "Progress
 
 ## Step 5 — Write research.md
 
-Write `design-system/projects/<slug>/research.md`:
+Write `projects/<slug>/research.md`:
 ```markdown
 # Research & Discovery: <Project Name>
 
@@ -144,7 +144,7 @@ Invoke pd-write-memory.
 ────────────────────────────────────────
 ✅  Discovery complete
 
-Research saved to design-system/projects/<slug>/research.md
+Research saved to projects/<slug>/research.md
 
 **What's next:** /pd:define — Map out user flows and build your screen inventory
 

--- a/skills/pd-gap-report/SKILL.md
+++ b/skills/pd-gap-report/SKILL.md
@@ -24,7 +24,7 @@ Log a missing component and coordinate resolution.
 
 ## Step 1 — Check if gap already logged
 
-Read `design-system/projects/<slug>/component-gaps.md`.
+Read `projects/<slug>/component-gaps.md`.
 If the component is already listed → update the `screens` column to include the new screen. Do not duplicate.
 
 ---

--- a/skills/pd-handoff/SKILL.md
+++ b/skills/pd-handoff/SKILL.md
@@ -16,12 +16,12 @@ Generate the development handoff: a Figma handoff page and a markdown spec docum
 ## Step 1 — Load context
 
 Read:
-- `design-system/projects/<slug>/brief.md`
-- `design-system/projects/<slug>/flows.md`
-- `design-system/projects/<slug>/screen-inventory.md`
-- `design-system/projects/<slug>/directions.md`
-- `design-system/projects/<slug>/component-gaps.md`
-- `design-system/projects/<slug>/active_session.md`
+- `projects/<slug>/brief.md`
+- `projects/<slug>/flows.md`
+- `projects/<slug>/screen-inventory.md`
+- `projects/<slug>/directions.md`
+- `projects/<slug>/component-gaps.md`
+- `projects/<slug>/active_session.md`
 - `design-system/knowledge-base/components.md`
 - `design-system/config.md`
 
@@ -67,7 +67,7 @@ Organize by flow: create a labeled section per flow on the handoff page.
 
 ## Step 3 — Generate markdown handoff document
 
-Write `design-system/projects/<slug>/handoff/<slug>-handoff.md`:
+Write `projects/<slug>/handoff/<slug>-handoff.md`:
 
 ```markdown
 # Development Handoff: <Project Name>
@@ -225,12 +225,12 @@ Update `active_session.md`:
 ```markdown
 ### Handoff
 status: complete
-handoff_doc: design-system/projects/<slug>/handoff/<slug>-handoff.md
+handoff_doc: projects/<slug>/handoff/<slug>-handoff.md
 figma_page: PDA — <Project Name> — Handoff
 screens_handed_off: <n>
 ```
 
-Update `design-system/projects/PROJECTS.md` — set project status to `handoff-complete`.
+Update `projects/PROJECTS.md` — set project status to `handoff-complete`.
 
 Invoke pd-write-memory.
 
@@ -242,7 +242,7 @@ Invoke pd-write-memory.
 ────────────────────────────────────────
 ✅  Handoff complete: <Project Name>
 
-📄  Spec doc:   design-system/projects/<slug>/handoff/<slug>-handoff.md
+📄  Spec doc:   projects/<slug>/handoff/<slug>-handoff.md
 🎨  Figma page: PDA — <Project Name> — Handoff
 
 <n> screens · <n> flows · <n> components documented

--- a/skills/pd-new-project/SKILL.md
+++ b/skills/pd-new-project/SKILL.md
@@ -15,7 +15,7 @@ Initialize a product design project: ingest or write a brief, create project mem
 
 ## Step 1 — Load context
 
-Read `design-system/projects/PROJECTS.md` if it exists. Note any existing projects.
+Read `projects/PROJECTS.md` if it exists. Note any existing projects.
 
 ---
 
@@ -104,7 +104,7 @@ Slugify the name: lowercase, hyphens, no spaces. E.g., `donor-portal`, `checkout
 
 Create the following files:
 
-**`design-system/projects/<slug>/brief.md`**
+**`projects/<slug>/brief.md`**
 ```markdown
 # Project Brief: <Project Name>
 
@@ -142,7 +142,7 @@ pending
 <original source URL or "written in session">
 ```
 
-**`design-system/projects/<slug>/screen-inventory.md`**
+**`projects/<slug>/screen-inventory.md`**
 ```markdown
 # Screen Inventory: <Project Name>
 
@@ -152,7 +152,7 @@ pending
 |--------|------|----------|--------|------------|-------|
 ```
 
-**`design-system/projects/<slug>/component-gaps.md`**
+**`projects/<slug>/component-gaps.md`**
 ```markdown
 # Component Gaps: <Project Name>
 
@@ -163,7 +163,7 @@ pending
 |-----------|--------|-------------------|--------|------|
 ```
 
-**`design-system/projects/<slug>/directions.md`**
+**`projects/<slug>/directions.md`**
 ```markdown
 # Directions: <Project Name>
 
@@ -173,7 +173,7 @@ pending
 |------|-------------------|------------------|-----------|------|
 ```
 
-**`design-system/projects/<slug>/active_session.md`**
+**`projects/<slug>/active_session.md`**
 ```markdown
 # Active Session
 
@@ -191,7 +191,7 @@ status: complete
 brief_source: <source>
 ```
 
-Update `design-system/projects/PROJECTS.md`:
+Update `projects/PROJECTS.md`:
 - Add row: `| <Project Name> | <slug> | DISCOVER | in_progress | <date> |`
 
 ---
@@ -202,7 +202,7 @@ Update `design-system/projects/PROJECTS.md`:
 ────────────────────────────────────────
 ✅  Project initialized: <Project Name>
 
-Brief saved to design-system/projects/<slug>/brief.md
+Brief saved to projects/<slug>/brief.md
 
 **What's next:** /pd:discover — Research, ideation, and problem framing
 

--- a/skills/pd-resume/SKILL.md
+++ b/skills/pd-resume/SKILL.md
@@ -14,7 +14,7 @@ Restore project context from memory and continue from the last checkpoint.
 
 ## Step 1 — Load checkpoint
 
-Read `design-system/projects/<slug>/active_session.md`.
+Read `projects/<slug>/active_session.md`.
 
 If no `active_session.md` exists or `status: complete` → tell user:
 > "No in-progress session found. Use `/pd:status` to see your projects or `/pd:new-project` to start one."

--- a/skills/pd-status/SKILL.md
+++ b/skills/pd-status/SKILL.md
@@ -14,7 +14,7 @@ Show a full project overview: phase, screen inventory, gaps, and what's next.
 
 ## Step 1 — Identify active project
 
-Read `design-system/projects/PROJECTS.md`.
+Read `projects/PROJECTS.md`.
 
 If one project with `status: in_progress` → use it.
 If multiple in-progress projects → ask:
@@ -33,11 +33,11 @@ If no active project → show PROJECTS.md summary and suggest `/pd:new-project`.
 ## Step 2 — Load project files
 
 Read:
-- `design-system/projects/<slug>/brief.md`
-- `design-system/projects/<slug>/screen-inventory.md`
-- `design-system/projects/<slug>/component-gaps.md`
-- `design-system/projects/<slug>/active_session.md`
-- `design-system/projects/<slug>/directions.md`
+- `projects/<slug>/brief.md`
+- `projects/<slug>/screen-inventory.md`
+- `projects/<slug>/component-gaps.md`
+- `projects/<slug>/active_session.md`
+- `projects/<slug>/directions.md`
 
 ---
 

--- a/skills/pd-write-memory/SKILL.md
+++ b/skills/pd-write-memory/SKILL.md
@@ -16,13 +16,13 @@ Persist session changes to product design project memory files.
 
 Review the current session's actions. Identify which files need updating:
 
-- `design-system/projects/<slug>/screen-inventory.md` — if screens were added, designed, or annotated
-- `design-system/projects/<slug>/component-gaps.md` — if gaps were logged or resolved
-- `design-system/projects/<slug>/directions.md` — if a concept direction was locked
-- `design-system/projects/<slug>/flows.md` — if flows were defined or updated
-- `design-system/projects/<slug>/research.md` — if discovery content was written
-- `design-system/projects/<slug>/active_session.md` — always updated with current phase and checkpoint
-- `design-system/projects/PROJECTS.md` — if project phase changed
+- `projects/<slug>/screen-inventory.md` — if screens were added, designed, or annotated
+- `projects/<slug>/component-gaps.md` — if gaps were logged or resolved
+- `projects/<slug>/directions.md` — if a concept direction was locked
+- `projects/<slug>/flows.md` — if flows were defined or updated
+- `projects/<slug>/research.md` — if discovery content was written
+- `projects/<slug>/active_session.md` — always updated with current phase and checkpoint
+- `projects/PROJECTS.md` — if project phase changed
 
 ---
 

--- a/skills/product-design-help/SKILL.md
+++ b/skills/product-design-help/SKILL.md
@@ -14,7 +14,7 @@ Explain the Product Designer Agent: what it does, the design phases, and when to
 ## Procedure
 
 ### Step 1 — Load state
-Read `design-system/projects/PROJECTS.md` (skip if missing) to check for active projects.
+Read `projects/PROJECTS.md` (skip if missing) to check for active projects.
 
 ### Step 2 — Present explanation
 
@@ -64,7 +64,7 @@ Each project moves through sequential phases. You can jump to any phase directly
 - Each phase ends with a checkpoint saved to `design-system/memory/active_session.md`.
 - Running `/product-designer` after a break detects the checkpoint and offers to resume.
 - If context gets too long (>60% usage), the agent warns you — `/clear` then `/product-designer` to resume safely.
-- All project files live in `design-system/projects/<project-slug>/`.
+- All project files live in `projects/<project-slug>/`.
 
 ---
 
@@ -82,6 +82,6 @@ Each project moves through sequential phases. You can jump to any phase directly
 ```
 
 ## Rules
-- Fill in active projects from `design-system/projects/PROJECTS.md` if it exists
+- Fill in active projects from `projects/PROJECTS.md` if it exists
 - If the file is missing or empty, show the "No projects yet" message
 - Keep output scannable — tables as presented, no extra prose

--- a/skills/product-designer/SKILL.md
+++ b/skills/product-designer/SKILL.md
@@ -18,7 +18,7 @@ Unified agent for end-to-end product design: from brief to fully designed, annot
 ## Step 1 — Load context and check for in-progress session
 
 Read these files (skip gracefully if missing):
-- `design-system/projects/PROJECTS.md` — all projects and their current phase
+- `projects/PROJECTS.md` — all projects and their current phase
 - `design-system/memory/active_session.md` — in-progress checkpoint
 
 **If `active_session.md` exists and has `status: in_progress` and `agent: product-designer`:**
@@ -83,5 +83,5 @@ options:
 - Never assume which project to work on if multiple exist — ask
 - Surface the "What's next" footer at the end of every phase
 - If context usage is above 60% → warn: "Context is getting full. Your work is checkpointed — you can `/clear` and run `/product-designer` to resume."
-- All project memory lives under `design-system/projects/<project-slug>/`
+- All project memory lives under `projects/<project-slug>/`
 - Never modify `design-system/knowledge-base/` unless a component gap was resolved via ds-plan/ds-build


### PR DESCRIPTION
Project files now live at projects/<slug>/ instead of design-system/projects/<slug>/. The design-system/ folder is for design system assets only; product projects are separate.

Updated all pd-* skills and install.sh scaffolding.