### PR TITLE
feat: DDD/ restructure, doc generation, smarter resume & ds-update pagination fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,17 +120,17 @@ design system, executor) — you never do the design or engineering yourself.
   - Task: a single unit of work in one workstream
 
 ## Memory Structure
-All project plans live under `projects/<slug>/plan/`.
-  - `projects/PROJECTS.md` — index of all projects (shared with pd-*)
-  - `projects/<slug>/brief.md` — product brief (shared with pd-*)
-  - `projects/<slug>/plan/master-plan.md` — phases, features, gates, dependency graph
-  - `projects/<slug>/plan/features/<feature>.md` — feature execution bundles
-  - `projects/<slug>/plan/active_session.md` — planner checkpoint
+All project plans live under `DDD/projects/<slug>/plan/`.
+  - `DDD/projects/PROJECTS.md` — index of all projects (shared with pd-*)
+  - `DDD/projects/<slug>/brief.md` — product brief (shared with pd-*)
+  - `DDD/projects/<slug>/plan/master-plan.md` — phases, features, gates, dependency graph
+  - `DDD/projects/<slug>/plan/features/<feature>.md` — feature execution bundles
+  - `DDD/projects/<slug>/plan/active_session.md` — planner checkpoint
 
 ## Ownership Boundaries
-  - Planner owns: `projects/<slug>/plan/`
-  - PD agent owns: `projects/<slug>/design/` and `projects/<slug>/handoff/`
-  - Executor owns: `projects/<slug>/dev/`
+  - Planner owns: `DDD/projects/<slug>/plan/`
+  - PD agent owns: `DDD/projects/<slug>/design/` and `DDD/projects/<slug>/handoff/`
+  - Executor owns: `DDD/projects/<slug>/dev/`
   - DS agent owns: `design-system/`
   - Never write to another agent's directory. Read only for gate detection and Pass 2.
 
@@ -170,7 +170,7 @@ write code directly — you delegate to architect, backend, frontend, and verifi
   - exec-code-mapper: scans codebase → reference docs (standalone)
 
 ## Memory Structure
-All execution state lives under `projects/<slug>/dev/`:
+All execution state lives under `DDD/projects/<slug>/dev/`:
   - `dev/architecture.md` — stack, patterns, conventions (from code-mapper)
   - `dev/api-map.md` — API routes (from code-mapper, updated by exec-backend)
   - `dev/component-map.md` — frontend components (from code-mapper, updated by exec-frontend)
@@ -179,8 +179,8 @@ All execution state lives under `projects/<slug>/dev/`:
   - `dev/active_session.md` — ephemeral checkpoint for exec-resume
 
 ## Ownership Boundaries
-  - Executor owns: `projects/<slug>/dev/`
-  - Reads: `projects/<slug>/plan/` (feature bundles), `projects/<slug>/handoff/` (design specs)
+  - Executor owns: `DDD/projects/<slug>/dev/`
+  - Reads: `DDD/projects/<slug>/plan/` (feature bundles), `DDD/projects/<slug>/handoff/` (design specs)
   - Reads: `design-system/knowledge-base/` (component/token reference)
   - Never writes to: `plan/`, `design/`, `handoff/`, `design-system/`
 

--- a/DDD/projects/PROJECTS.md
+++ b/DDD/projects/PROJECTS.md
@@ -1,0 +1,6 @@
+# Projects
+
+> Managed by /plan:project and /pd:new-project. Updated by plan-write-memory and pd-write-memory after each session.
+
+| Project | Slug | Phase | Status | Last Updated |
+|---------|------|-------|--------|--------------|

--- a/skills/ds-update/SKILL.md
+++ b/skills/ds-update/SKILL.md
@@ -29,12 +29,43 @@ If different:
 - Update version in config.md
 
 ### Step 3 — Re-scan Figma
-Run the same scans as ds-init:
-- `figma_get_variables` → new token state
-- `figma_search_components` + `figma_get_component_details` → new component state
-- `figma_get_styles` → new style state
 
-  If `figma_get_styles` returns zero styles (sync API throws on dynamic-page documents), fall back to `figma_execute`:
+**Variables — use `figma_execute` only (never `figma_get_variables`).**
+`figma_get_variables` paginates and silently truncates results. Always fetch all variables
+in a single JavaScript call:
+
+```javascript
+const collections = figma.variables.getLocalVariableCollections();
+const allVars = figma.variables.getLocalVariables();
+
+return JSON.stringify(collections.map(col => ({
+  name: col.name,
+  modes: col.modes,
+  variables: allVars
+    .filter(v => v.variableCollectionId === col.id)
+    .map(v => ({
+      name: v.name,
+      valuesByMode: Object.fromEntries(
+        col.modes.map(m => {
+          const val = v.valuesByMode[m.modeId];
+          if (val?.type === 'VARIABLE_ALIAS') {
+            const ref = figma.variables.getVariableById(val.id);
+            return [m.name, `alias:${ref?.name ?? val.id}`];
+          }
+          if (val?.r !== undefined) {
+            return [m.name, `rgba(${Math.round(val.r*255)},${Math.round(val.g*255)},${Math.round(val.b*255)},${val.a?.toFixed(2)})`];
+          }
+          return [m.name, val];
+        })
+      )
+    }))
+})));
+```
+
+**Components and styles** — run in parallel:
+- `figma_search_components` + `figma_get_component_details` → new component state
+- `figma_get_styles` → new style state. If it returns zero styles (sync API throws on
+  dynamic-page documents), fall back to `figma_execute`:
   ```javascript
   const [textStyles, paintStyles, effectStyles] = await Promise.all([
     figma.getLocalTextStylesAsync(),
@@ -48,37 +79,68 @@ Run the same scans as ds-init:
   });
   ```
 
-### Step 4 — Compute semantic diff
-Compare old vs. new state for each knowledge-base file:
+### Step 3b — Coverage check (abort if scan is incomplete)
+
+Before any diffing, verify the scan is complete:
+
+1. Count total variables in the fresh scan across all collections.
+2. Count total variables currently tracked in `tokens.md`.
+3. Verify every group name from `tokens.md` appears in the fresh scan.
+
+**If either check fails — ABORT. Do not proceed to diff.**
+
+```
+Scan incomplete: knowledge-base tracks N variables but scan returned M.
+Possible causes: Figma connection issue, wrong file, API truncation.
+Aborting to prevent data loss. Re-run /ds-update or reconnect Figma.
+```
+
+Never silently treat a missing group as "no changes."
+
+### Step 4 — Compute three-way semantic diff
+
+For each category, compute three disjoint sets:
+
+| Set | Logic | Label |
+|-----|-------|-------|
+| **Changed** | exists in KB and in scan, but value differs | `Changed:` |
+| **Removed** | exists in KB but absent from fresh scan | `Removed:` |
+| **Added** | exists in fresh scan but absent from KB | `Added:` |
+
+Apply at two granularities for tokens:
+- **Group level** — entirely new collection or group prefix (e.g., a new `chart/` group)
+- **Token level** — new individual token within an existing group
 
 **Tokens:**
-- New tokens added
-- Tokens removed
-- Token values changed (note which modes)
+- Added groups (new collection or prefix not in KB)
+- Added tokens within existing groups
+- Removed groups (in KB but absent from scan — after coverage check passed)
+- Removed tokens within existing groups
+- Changed token values (note which modes changed and old → new value)
 - New collections or modes added
 
 **Components:**
-- New components added
-- Components removed
-- Variants/properties changed on existing components
-- Children changed (composition changes)
-- Handle renames: if a component disappeared and a new one appeared with similar
-  structure/properties, flag as potential rename
+- Added components (in scan, not in KB)
+- Removed components (in KB, not in scan)
+- Modified: variants/properties changed on existing components
+- Modified: children changed (composition changes)
+- Possible renames: component disappeared and new one appeared with similar structure/properties
 
 **Styles:**
-- New styles added
-- Styles removed
-- Style values changed
+- Added styles
+- Removed styles
+- Changed style values
 
 ### Step 5 — Present diff
 
 ```
 ## Design System Update — Changes Detected
+Scan coverage: <N> variables fetched / <M> in KB ✓
 
 ### Tokens (<N> changes)
-- **Added:** <list>
-- **Removed:** <list>
-- **Changed:** <list with old → new values>
+- **Added:** <list — include new groups and individual tokens>
+- **Removed:** <list — include removed groups and individual tokens>
+- **Changed:** <list with old → new values, noting which modes>
 
 ### Components (<N> changes)
 - **Added:** <list>
@@ -95,7 +157,9 @@ Compare old vs. new state for each knowledge-base file:
 <list categories with no changes>
 ```
 
-If no changes detected: "Knowledge-base is up to date."
+If no changes detected: "Knowledge-base is up to date. Scan: <N> variables verified."
+
+Always show the scan coverage line so the user can confirm the scan was complete.
 
 ### Step 6 — Confirm and write
 Ask user to confirm before writing:
@@ -112,6 +176,11 @@ On confirmation:
 Invoke write-memory to update MEMORY.md.
 
 ## Rules
+- **NEVER use `figma_get_variables`** — it paginates and silently truncates; always use `figma_execute` to fetch all variables in one call
+- **NEVER diff with incomplete scan data** — if coverage check fails, abort immediately with a clear message
+- **NEVER treat a missing group as unchanged** — absent groups are either Removed (if coverage passed) or scan failures (if coverage failed)
+- **Diff is always three-way** — every category reports Added, Removed, and Changed; never just Changed
+- **Show scan coverage on every run** — the count line lets the user verify completeness at a glance
 - NEVER overwrite knowledge-base without showing the diff first
 - NEVER overwrite without user confirmation
 - If the scan returns drastically different results (>50% change), warn the user —

--- a/skills/exec-architect/SKILL.md
+++ b/skills/exec-architect/SKILL.md
@@ -20,7 +20,7 @@ Produce architecture decisions for a set of tasks within a feature execution sta
 
 ## Inputs (passed from exec-feature)
 
-- `feature_bundle` — the full feature plan from `projects/<slug>/plan/features/<feature>.md`
+- `feature_bundle` — the full feature plan from `DDD/projects/<slug>/plan/features/<feature>.md`
 - `stage` — which stage: `backend` or `frontend`
 - `tasks` — the list of tasks for this stage from the bundle
 
@@ -28,7 +28,7 @@ Produce architecture decisions for a set of tasks within a feature execution sta
 
 ## Step 1 — Load reference docs
 
-Read all available reference docs from `projects/<slug>/dev/`:
+Read all available reference docs from `DDD/projects/<slug>/dev/`:
 - `architecture.md` — stack, conventions, patterns
 - `api-map.md` — existing API routes
 - `component-map.md` — existing frontend components
@@ -118,9 +118,21 @@ If any task has:
 
 | Task | Flag | Impact |
 |------|------|--------|
-| <task> | Schema change | Requires migration — will update db-schema.md |
+| <task> | Schema change | Requires migration — will update db-schema.md + docs/DATABASE.md |
+| <task> | New API route | Will update docs/TECHNICAL_DOCUMENTATION.md |
+| <task> | Auth change | Will update docs/AUTHENTICATION.md |
 | <task> | No precedent | No existing pattern for WebSocket handlers — needs architect decision |
 ```
+
+For each task block, add a **Docs Impact** line listing which docs exec-backend must update:
+
+```markdown
+#### Docs Impact
+- `DDD/projects/<slug>/docs/DATABASE.md` — new trades table
+- `DDD/projects/<slug>/docs/TECHNICAL_DOCUMENTATION.md` — POST /api/trades route
+```
+
+Omit the Docs Impact section if a task has no documentation side effects.
 
 ---
 
@@ -140,3 +152,4 @@ task block to exec-backend or exec-frontend for each task.
 - **One task = one atomic unit** — each task block must be independently executable
 - **Respect CLAUDE.md rules** — architecture decisions must align with project rules (auth patterns, type system, etc.)
 - **DB changes are explicit** — if a task requires a migration, say so in the files table and flags
+- **Docs impact is explicit** — tag every task with which project docs in `DDD/projects/<slug>/docs/` exec-backend must update

--- a/skills/exec-architect/SKILL.md
+++ b/skills/exec-architect/SKILL.md
@@ -137,7 +137,20 @@ Omit the Docs Impact section if a task has no documentation side effects.
 
 ---
 
-## Step 5 — Return to exec-feature
+## Step 5 — Spawn task-verifier
+
+Before returning, spawn task-verifier as a subagent with:
+- `artifact_type`: `architecture`
+- `artifact_paths`: the architecture output just produced (inline — pass the full text)
+- `criteria`: the task list for this stage from the feature bundle
+- `context_paths`: `DDD/projects/<slug>/dev/architecture.md`, the feature bundle
+
+If BLOCK → fix the flagged issues in the architecture decisions before returning to exec-feature. Do not return a plan with known gaps.
+If WARN → include the warnings in the return output so exec-feature can surface them.
+
+---
+
+## Step 6 — Return to exec-feature
 
 Return the full architecture output as structured context. exec-feature passes the relevant
 task block to exec-backend or exec-frontend for each task.
@@ -154,3 +167,4 @@ task block to exec-backend or exec-frontend for each task.
 - **Respect CLAUDE.md rules** — architecture decisions must align with project rules (auth patterns, type system, etc.)
 - **DB changes are explicit** — if a task requires a migration, say so in the files table and flags
 - **Docs impact is explicit** — tag every task with which project docs in `DDD/projects/<slug>/docs/` exec-backend must update
+- **Self-verify before returning** — always spawn task-verifier on the architecture output; never return a plan with a BLOCK verdict

--- a/skills/exec-architect/SKILL.md
+++ b/skills/exec-architect/SKILL.md
@@ -6,8 +6,9 @@ description: >
   Internal architecture agent for the executor. Reads a feature bundle and reference
   docs, produces per-task architecture decisions: file paths, patterns to follow,
   data flow, and dependencies. Called by exec-feature before each execution stage.
-  Output is passed in-context to exec-backend or exec-frontend — not persisted.
-  Never invoked directly by the user.
+  Output is written to DDD/projects/<slug>/dev/architect-<feature-slug>-<stage>.md
+  by exec-feature immediately after the run. On resume, exec-feature loads that file
+  instead of re-running this skill. Never invoked directly by the user.
 ---
 
 # Exec Architect

--- a/skills/exec-backend/SKILL.md
+++ b/skills/exec-backend/SKILL.md
@@ -100,6 +100,52 @@ After writing code, update the relevant reference docs inline:
 
 ---
 
+## Step 5b — Update project documentation
+
+After writing code, update the project's documentation in `DDD/projects/<slug>/docs/`.
+Create the `docs/` directory if it doesn't exist.
+
+**Trigger rules — only update docs that match what changed:**
+
+| What changed | Doc to update |
+|---|---|
+| New or modified API routes | `docs/TECHNICAL_DOCUMENTATION.md` |
+| New tables, columns, or migrations | `docs/DATABASE.md` |
+| Auth flow added or modified | `docs/AUTHENTICATION.md` |
+| System architecture or patterns changed | `docs/ARCHITECTURE.md` |
+
+**Format for each update:**
+```markdown
+## [Section]
+
+**Changed:** <date>
+**Change Type:** Addition | Modification | Deprecation
+**Reason:** <why this change was made>
+
+<Updated content — table or description>
+```
+
+**`docs/TECHNICAL_DOCUMENTATION.md`** — for new or modified API routes:
+- Add route under the relevant section (Auth, Setups, Trades, etc.)
+- Include method, path, auth required, request/response shapes, error codes
+- Note any validation rules or side effects
+
+**`docs/DATABASE.md`** — for schema changes:
+- Add or update table definition with columns, types, constraints
+- Include migration script reference
+- Add RLS policy descriptions
+- Update relationship diagram if tables were added
+
+**`docs/AUTHENTICATION.md`** — for auth changes:
+- Update auth flow steps if the flow changed
+- Add new token types, session handling, or middleware behavior
+
+**`docs/ARCHITECTURE.md`** — for pattern or design changes:
+- Update the relevant pattern section
+- Note why the existing pattern was extended or changed
+
+---
+
 ## Step 6 — Git commit
 
 Stage the files written in this task and commit:
@@ -133,6 +179,10 @@ Return a structured result:
 - api-map.md: added <n> routes
 - db-schema.md: added <n> tables
 
+**Project docs updated:**
+- docs/TECHNICAL_DOCUMENTATION.md: <added/updated sections or "no changes">
+- docs/DATABASE.md: <added/updated sections or "no changes">
+
 **Commit:** <commit hash — first 7 chars>
 
 **Acceptance criteria status:**
@@ -151,6 +201,7 @@ Return a structured result:
 - **Auth on every route** — if the project requires auth, every API route must validate it
 - **Validation before DB** — always validate inputs before database operations
 - **Update reference docs** — every new route goes in api-map.md, every schema change goes in db-schema.md
+- **Update project docs** — schema changes → docs/DATABASE.md, new routes → docs/TECHNICAL_DOCUMENTATION.md, auth changes → docs/AUTHENTICATION.md, all in `DDD/projects/<slug>/docs/`
 - **Commit per task** — atomic commits with clear messages
 - **Don't touch frontend** — if a task mentions UI, flag it and return to exec-feature
 - **Don't modify non-task files** — only touch files listed in the architect's file table, plus reference docs

--- a/skills/exec-backend/SKILL.md
+++ b/skills/exec-backend/SKILL.md
@@ -100,21 +100,30 @@ After writing code, update the relevant reference docs inline:
 
 ---
 
-## Step 5b — Update project documentation
+## Step 5b — Update project documentation (MANDATORY — no exceptions)
 
-After writing code, update the project's documentation in `DDD/projects/<slug>/docs/`.
-Create the `docs/` directory if it doesn't exist.
+This step is not conditional. After every task, write to `DDD/projects/<slug>/docs/`.
+Create the `docs/` directory if it doesn't exist. Create any doc file that doesn't exist yet.
 
-**Trigger rules — only update docs that match what changed:**
+**For each of the four docs, write an update or a "reviewed — no changes" note:**
 
-| What changed | Doc to update |
-|---|---|
-| New or modified API routes | `docs/TECHNICAL_DOCUMENTATION.md` |
-| New tables, columns, or migrations | `docs/DATABASE.md` |
-| Auth flow added or modified | `docs/AUTHENTICATION.md` |
-| System architecture or patterns changed | `docs/ARCHITECTURE.md` |
+**`docs/TECHNICAL_DOCUMENTATION.md`**
+- If this task created or modified API routes → add the route(s) with method, path, auth required, request/response shapes, error codes, validation rules
+- If no routes touched → append: `<!-- <task-title>: no API changes -->`
 
-**Format for each update:**
+**`docs/DATABASE.md`**
+- If this task created or modified tables, columns, or migrations → add table definition with columns, types, constraints, RLS policies, migration script reference
+- If no schema touched → append: `<!-- <task-title>: no schema changes -->`
+
+**`docs/AUTHENTICATION.md`**
+- If this task touched auth flow, middleware, tokens, or session handling → update the relevant section
+- If auth not touched → append: `<!-- <task-title>: no auth changes -->`
+
+**`docs/ARCHITECTURE.md`**
+- If this task introduced a new pattern, changed a convention, or modified system design → update the relevant section
+- If architecture not touched → append: `<!-- <task-title>: no architecture changes -->`
+
+**Format for actual updates:**
 ```markdown
 ## [Section]
 
@@ -125,28 +134,14 @@ Create the `docs/` directory if it doesn't exist.
 <Updated content — table or description>
 ```
 
-**`docs/TECHNICAL_DOCUMENTATION.md`** — for new or modified API routes:
-- Add route under the relevant section (Auth, Setups, Trades, etc.)
-- Include method, path, auth required, request/response shapes, error codes
-- Note any validation rules or side effects
-
-**`docs/DATABASE.md`** — for schema changes:
-- Add or update table definition with columns, types, constraints
-- Include migration script reference
-- Add RLS policy descriptions
-- Update relationship diagram if tables were added
-
-**`docs/AUTHENTICATION.md`** — for auth changes:
-- Update auth flow steps if the flow changed
-- Add new token types, session handling, or middleware behavior
-
-**`docs/ARCHITECTURE.md`** — for pattern or design changes:
-- Update the relevant pattern section
-- Note why the existing pattern was extended or changed
+**Do not skip this step.** If you reach the git commit without having written to all four docs, go back and write them first.
 
 ---
 
 ## Step 6 — Git commit
+
+**Before staging: verify Step 5b is complete.** All four doc files must have been written
+(updated or "no changes" comment). If any are missing, write them now before continuing.
 
 Stage the files written in this task and commit:
 
@@ -179,9 +174,11 @@ Return a structured result:
 - api-map.md: added <n> routes
 - db-schema.md: added <n> tables
 
-**Project docs updated:**
-- docs/TECHNICAL_DOCUMENTATION.md: <added/updated sections or "no changes">
-- docs/DATABASE.md: <added/updated sections or "no changes">
+**Project docs updated (all four required):**
+- docs/TECHNICAL_DOCUMENTATION.md: <what was added/updated, or "no changes — comment written">
+- docs/DATABASE.md: <what was added/updated, or "no changes — comment written">
+- docs/AUTHENTICATION.md: <what was added/updated, or "no changes — comment written">
+- docs/ARCHITECTURE.md: <what was added/updated, or "no changes — comment written">
 
 **Commit:** <commit hash — first 7 chars>
 
@@ -201,7 +198,7 @@ Return a structured result:
 - **Auth on every route** — if the project requires auth, every API route must validate it
 - **Validation before DB** — always validate inputs before database operations
 - **Update reference docs** — every new route goes in api-map.md, every schema change goes in db-schema.md
-- **Update project docs** — schema changes → docs/DATABASE.md, new routes → docs/TECHNICAL_DOCUMENTATION.md, auth changes → docs/AUTHENTICATION.md, all in `DDD/projects/<slug>/docs/`
+- **Update project docs — always, no exceptions** — write all four docs in `DDD/projects/<slug>/docs/` after every task; write a `<!-- no changes -->` comment for categories not touched; never skip this step
 - **Commit per task** — atomic commits with clear messages
 - **Don't touch frontend** — if a task mentions UI, flag it and return to exec-feature
 - **Don't modify non-task files** — only touch files listed in the architect's file table, plus reference docs

--- a/skills/exec-backend/SKILL.md
+++ b/skills/exec-backend/SKILL.md
@@ -83,6 +83,20 @@ For each file:
 
 ---
 
+## Step 4b — Spawn task-verifier
+
+After writing all code for this task, spawn task-verifier as a subagent with:
+- `artifact_type`: `code`
+- `artifact_paths`: all files written in Step 4
+- `criteria`: the task's acceptance criteria from the feature bundle
+- `context_paths`: the architect context block for this task, `dev/architecture.md`
+
+**If BLOCK** → fix the flagged issues before proceeding to Step 5. Do not update docs or commit until the verifier passes.
+**If WARN** → note the warnings, continue. Surface them in the Step 7 return result.
+**If PASS** → continue.
+
+---
+
 ## Step 5 — Update reference docs
 
 After writing code, update the relevant reference docs inline:

--- a/skills/exec-code-mapper/SKILL.md
+++ b/skills/exec-code-mapper/SKILL.md
@@ -5,7 +5,7 @@ effort: high
 description: >
   Standalone codebase mapping agent. Scans an existing project codebase and produces
   structured reference docs (architecture.md, api-map.md, component-map.md, db-schema.md)
-  under projects/<slug>/dev/. Called by exec-map (user-facing) or by exec-feature when
+  under DDD/projects/<slug>/dev/. Called by exec-map (user-facing) or by exec-feature when
   no reference docs exist. Can also be invoked standalone for any codebase scan.
   Never invoked directly by the user — use /exec:map instead.
 ---
@@ -20,7 +20,7 @@ Scan a project codebase and produce structured reference documentation for the e
 
 ## Step 1 — Identify project and codebase root
 
-Read `projects/PROJECTS.md` if it exists. Identify the active project.
+Read `DDD/projects/PROJECTS.md` if it exists. Identify the active project.
 
 If the project has a `brief.md`, read it for tech stack hints.
 
@@ -75,7 +75,7 @@ Map the top-level directory tree (2 levels deep). Identify:
 
 ## Step 4 — Produce architecture.md
 
-Write `projects/<slug>/dev/architecture.md`:
+Write `DDD/projects/<slug>/dev/architecture.md`:
 
 ```markdown
 # Architecture: <Project Name>
@@ -125,7 +125,7 @@ Write `projects/<slug>/dev/architecture.md`:
 
 Scan all API route files. For each route:
 
-Write `projects/<slug>/dev/api-map.md`:
+Write `DDD/projects/<slug>/dev/api-map.md`:
 
 ```markdown
 # API Map: <Project Name>
@@ -162,7 +162,7 @@ Write `projects/<slug>/dev/api-map.md`:
 
 Scan component directories. For each component:
 
-Write `projects/<slug>/dev/component-map.md`:
+Write `DDD/projects/<slug>/dev/component-map.md`:
 
 ```markdown
 # Component Map: <Project Name>
@@ -198,7 +198,7 @@ Write `projects/<slug>/dev/component-map.md`:
 
 Scan database schema files (migrations, Prisma schema, Supabase types, etc.):
 
-Write `projects/<slug>/dev/db-schema.md`:
+Write `DDD/projects/<slug>/dev/db-schema.md`:
 
 ```markdown
 # Database Schema: <Project Name>

--- a/skills/exec-feature/SKILL.md
+++ b/skills/exec-feature/SKILL.md
@@ -20,11 +20,11 @@ Orchestrate building a complete feature from its execution bundle.
 
 ## Step 1 — Load context and select feature
 
-Read `projects/PROJECTS.md`. Identify the active project.
+Read `DDD/projects/PROJECTS.md`. Identify the active project.
 
 If multiple active projects → use AskUserQuestion to pick one.
 
-Read `projects/<slug>/plan/master-plan.md`. List features with `status: ready-for-execution`.
+Read `DDD/projects/<slug>/plan/master-plan.md`. List features with `status: ready-for-execution`.
 
 If the user specified a feature → use it.
 If not → use AskUserQuestion:
@@ -36,7 +36,7 @@ options:
   - "<feature 3> — not yet ready (needs Pass 2)"
 ```
 
-Load the feature bundle from `projects/<slug>/plan/features/<feature-slug>.md`.
+Load the feature bundle from `DDD/projects/<slug>/plan/features/<feature-slug>.md`.
 Verify it has `status: ready-for-execution`. If not → tell user to run `/plan:feature` first.
 
 ---
@@ -74,7 +74,7 @@ Invoke exec-code-mapper. After completion, return to this step and re-ask
 
 ## Step 3 — Reference docs check
 
-Check if `projects/<slug>/dev/architecture.md` exists.
+Check if `DDD/projects/<slug>/dev/architecture.md` exists.
 
 - **Exists** → read it, confirm it's reasonably current
 - **Missing** → invoke exec-code-mapper to generate reference docs before proceeding

--- a/skills/exec-feature/SKILL.md
+++ b/skills/exec-feature/SKILL.md
@@ -152,12 +152,21 @@ Extract all backend tasks from the feature bundle (including any backend revisio
 
 ### 2a — Architecture planning
 
-Invoke exec-architect with:
-- The feature bundle
-- Stage: `backend`
-- All backend tasks
+**First — check for saved architect output.**
+Look for `DDD/projects/<slug>/dev/architect-<feature-slug>-backend.md`.
 
-Review the architect's output. If flags exist (schema changes, no precedent, ambiguity):
+- **File exists** → read it and use it as the architect context. Do NOT re-run exec-architect.
+  Show: "Loading saved architect plan for backend stage."
+- **File missing** → invoke exec-architect with:
+  - The feature bundle
+  - Stage: `backend`
+  - All backend tasks
+
+  After exec-architect returns, immediately write its full output to
+  `DDD/projects/<slug>/dev/architect-<feature-slug>-backend.md` before proceeding.
+  This file is the resume checkpoint for the architect stage.
+
+Review the architect's output (loaded or fresh). If flags exist (schema changes, no precedent, ambiguity):
 
 Use AskUserQuestion:
 ```
@@ -241,10 +250,18 @@ Extract all frontend tasks from the feature bundle.
 
 ### 3a — Architecture planning
 
-Invoke exec-architect with:
-- The feature bundle (including design context section)
-- Stage: `frontend`
-- All frontend tasks
+**First — check for saved architect output.**
+Look for `DDD/projects/<slug>/dev/architect-<feature-slug>-frontend.md`.
+
+- **File exists** → read it and use it as the architect context. Do NOT re-run exec-architect.
+  Show: "Loading saved architect plan for frontend stage."
+- **File missing** → invoke exec-architect with:
+  - The feature bundle (including design context section)
+  - Stage: `frontend`
+  - All frontend tasks
+
+  After exec-architect returns, immediately write its full output to
+  `DDD/projects/<slug>/dev/architect-<feature-slug>-frontend.md` before proceeding.
 
 ### 3b — Task execution loop (wave-parallel)
 

--- a/skills/exec-frontend/SKILL.md
+++ b/skills/exec-frontend/SKILL.md
@@ -110,6 +110,20 @@ For each component:
 
 ---
 
+## Step 5b — Spawn task-verifier
+
+After writing all code for this task, spawn task-verifier as a subagent with:
+- `artifact_type`: `code`
+- `artifact_paths`: all files written in Step 5
+- `criteria`: the task's acceptance criteria from the feature bundle
+- `context_paths`: the architect context block, `dev/architecture.md`, the design context section from the feature bundle
+
+**If BLOCK** → fix the flagged issues before proceeding to Step 6. Do not update docs or commit until the verifier passes.
+**If WARN** → note the warnings, continue. Surface them in the Step 8 return result.
+**If PASS** → continue.
+
+---
+
 ## Step 6 — Update reference docs
 
 After writing code, update:

--- a/skills/exec-frontend/SKILL.md
+++ b/skills/exec-frontend/SKILL.md
@@ -121,7 +121,31 @@ After writing code, update:
 
 ---
 
+## Step 6b — Update project documentation (MANDATORY — no exceptions)
+
+Write to `DDD/projects/<slug>/docs/` after every task. Create the directory and any
+missing doc files. Two docs are in scope for frontend tasks:
+
+**`docs/TECHNICAL_DOCUMENTATION.md`**
+- If this task added new pages or client-side routes → document path, component, auth required, description
+- If no new pages/routes → append: `<!-- <task-title>: no route changes -->`
+
+**`docs/ARCHITECTURE.md`**
+- If this task introduced a new frontend pattern, component structure, or state management approach → document it
+- If no new patterns → append: `<!-- <task-title>: no architecture changes -->`
+
+`docs/DATABASE.md` and `docs/AUTHENTICATION.md` are backend concerns — do not write to them from frontend tasks.
+
+**Do not skip this step.** Both docs must be written before the git commit.
+
+---
+
 ## Step 7 — Git commit
+
+**Before staging: verify Step 6b is complete.** Both doc files must have been written
+(updated or "no changes" comment). If either is missing, write them now before continuing.
+
+
 
 Stage the files written in this task and commit:
 
@@ -159,6 +183,10 @@ Return a structured result:
 **Reference docs updated:**
 - component-map.md: added <n> components
 
+**Project docs updated:**
+- docs/TECHNICAL_DOCUMENTATION.md: <what was added/updated, or "no changes — comment written">
+- docs/ARCHITECTURE.md: <what was added/updated, or "no changes — comment written">
+
 **Commit:** <commit hash>
 
 **States implemented:**
@@ -190,6 +218,7 @@ Return a structured result:
 - **Wire to real endpoints** — use api-map.md for exact route paths and response shapes
 - **Don't touch backend** — if a task mentions API changes, flag it and return to exec-feature
 - **Update component-map.md** — every new component must be registered
+- **Update project docs — always, no exceptions** — write docs/TECHNICAL_DOCUMENTATION.md and docs/ARCHITECTURE.md after every task; write a `<!-- no changes -->` comment for categories not touched; never skip this step
 - **Read before write** — always read existing files before modifying
 - **Accessibility** — use semantic HTML, ARIA labels where needed, keyboard navigation (via shadcn/ui)
 - **Responsive** — mobile-first, use Tailwind breakpoints (sm, md, lg, xl)

--- a/skills/exec-map/SKILL.md
+++ b/skills/exec-map/SKILL.md
@@ -19,7 +19,7 @@ Scan a codebase and produce reference documentation for the executor sub-agents.
 
 ## Step 1 — Identify project
 
-Read `projects/PROJECTS.md` if it exists.
+Read `DDD/projects/PROJECTS.md` if it exists.
 
 If one active project → use it.
 If multiple → use AskUserQuestion to pick one.
@@ -33,13 +33,13 @@ options:
 ```
 
 If mapping without a project, use a temporary slug based on the directory name.
-Reference docs go to `projects/<slug>/dev/`.
+Reference docs go to `DDD/projects/<slug>/dev/`.
 
 ---
 
 ## Step 2 — Check for existing reference docs
 
-Check if `projects/<slug>/dev/architecture.md` exists.
+Check if `DDD/projects/<slug>/dev/architecture.md` exists.
 
 If exists → use AskUserQuestion:
 ```

--- a/skills/exec-resume/SKILL.md
+++ b/skills/exec-resume/SKILL.md
@@ -18,12 +18,91 @@ Restore execution context from checkpoint and continue building from the last ta
 
 ## Step 1 — Load checkpoint
 
-Find active sessions: look for `projects/*/dev/active_session.md`.
+Read `DDD/projects/PROJECTS.md` to find active projects.
 
-If no `active_session.md` exists or all have `status: complete`:
-> "No in-progress build session found. Use `/exec:feature` to start building a feature or `/plan:status` to see what's ready."
+For each active project, check `DDD/projects/<slug>/dev/active_session.md`.
+
+**Case A — In-progress session found** (status: in_progress):
+→ Continue to Step 2.
+
+**Case B — No session or all sessions complete**:
+→ Continue to Step 1b (intelligent next step detection).
 
 If multiple projects have in-progress sessions → use AskUserQuestion to pick one.
+
+---
+
+## Step 1b — Intelligent next step detection
+
+No active build session exists. Instead of stopping, look at the plan to find what comes next.
+
+For each active project, read in parallel:
+- `DDD/projects/<slug>/plan/master-plan.md`
+- `DDD/projects/<slug>/dev/status.md` (if exists)
+
+Then determine the executor's next logical action:
+
+### Check 1 — Partially built features
+
+Read `dev/status.md`. Look for any feature where at least one stage is `complete` but
+another is `not-started` or `in-progress`. These are partially built features that can resume.
+
+### Check 2 — Features ready for execution
+
+Read `master-plan.md`. Find features with `status: ready-for-execution` that do NOT appear
+in `dev/status.md` yet. These are features queued but not started.
+
+### Check 3 — Gate unblocks
+
+Read master-plan.md Gates section. For each gate with `status: pending`, check if the
+gate criterion file now exists (e.g., `handoff/<feature>-handoff.md`). If it does, the
+gate has been met — the blocked feature is now unblocked and buildable.
+
+### Check 4 — Features needing Pass 2
+
+Find features in master-plan.md that are `needs-design` and the design handoff exists
+(`DDD/projects/<slug>/handoff/<feature>-handoff.md`) but no execution bundle exists yet
+(`DDD/projects/<slug>/plan/features/<feature>.md` missing). These need `/plan:feature`
+(Pass 2) before they can be built.
+
+### Present findings
+
+After scanning all active projects, present a prioritized status:
+
+```
+--------------------------------------------
+  No active build session. Here's where things stand:
+
+  READY TO BUILD:
+  • [project] / <feature> — ready-for-execution, not started
+  • [project] / <feature> — backend complete, frontend queued
+
+  UNBLOCKED (gate just met):
+  • [project] / <feature> — design handoff found, ready to build
+
+  NEEDS PASS 2 FIRST:
+  • [project] / <feature> — handoff exists, execution bundle missing
+    → run /plan:feature <feature> first
+
+  WAITING ON DESIGN:
+  • [project] / <feature> — no handoff yet
+--------------------------------------------
+```
+
+Use AskUserQuestion:
+```
+question: "What would you like to do?"
+options:
+  - "Build <top ready feature> — start /exec:feature"
+  - "Run Pass 2 on <feature needing bundle> first"
+  - "Show full project status — /plan:status"
+  - "I want to build a different feature"
+```
+
+If user selects a feature to build → invoke exec-feature for that feature.
+If user selects Pass 2 → tell user to run `/plan:feature <feature>`.
+
+Do NOT stall — always surface the next actionable step.
 
 ---
 
@@ -91,8 +170,11 @@ If "Start stage over" → warn about existing commits, then re-run the current s
 
 ## Rules
 
+- **Never stall** — if no active session exists, scan the plan and surface the next action
 - **Never restart from scratch on resume** — skip to the last incomplete task
 - **Verify branch state** — make sure git state matches checkpoint before continuing
 - **If checkpoint references a feature that no longer exists** → warn and ask user
 - **If branch has diverged** (someone else pushed changes) → warn before continuing
 - **Always re-read reference docs on resume** — they may have been updated between sessions
+- **Gate detection is proactive** — always check if handoff files exist that weren't there before; a met gate is an actionable signal
+- **Surface Pass 2 needs explicitly** — if a handoff exists but no execution bundle, name the exact command to run

--- a/skills/exec-write-memory/SKILL.md
+++ b/skills/exec-write-memory/SKILL.md
@@ -20,6 +20,8 @@ Review the current session's actions. Identify which files need updating:
 
 - `DDD/projects/<slug>/dev/status.md` — if any feature stage progressed
 - `DDD/projects/<slug>/dev/active_session.md` — always updated with current skill and checkpoint
+- `DDD/projects/<slug>/dev/architect-<feature-slug>-backend.md` — if exec-architect ran for backend stage (write full architect output)
+- `DDD/projects/<slug>/dev/architect-<feature-slug>-frontend.md` — if exec-architect ran for frontend stage (write full architect output)
 - `DDD/projects/PROJECTS.md` — if project status changed (e.g., first feature started building)
 
 ---
@@ -100,6 +102,7 @@ Tell the calling skill what was written:
 
 ## Rules
 
+- **Architect output must be persisted** — if exec-architect ran this session, always write `architect-<feature-slug>-<stage>.md` before returning
 - Only touch files that actually changed — do not rewrite unchanged files
 - `active_session.md` is ALWAYS updated — it is the checkpoint
 - `status.md` is the gate signal — planner reads this for auto-detection

--- a/skills/exec-write-memory/SKILL.md
+++ b/skills/exec-write-memory/SKILL.md
@@ -10,7 +10,7 @@ description: >
 
 # Exec Write Memory
 
-Persist session changes to `projects/<slug>/dev/` files.
+Persist session changes to `DDD/projects/<slug>/dev/` files.
 
 ---
 
@@ -18,9 +18,9 @@ Persist session changes to `projects/<slug>/dev/` files.
 
 Review the current session's actions. Identify which files need updating:
 
-- `projects/<slug>/dev/status.md` — if any feature stage progressed
-- `projects/<slug>/dev/active_session.md` — always updated with current skill and checkpoint
-- `projects/PROJECTS.md` — if project status changed (e.g., first feature started building)
+- `DDD/projects/<slug>/dev/status.md` — if any feature stage progressed
+- `DDD/projects/<slug>/dev/active_session.md` — always updated with current skill and checkpoint
+- `DDD/projects/PROJECTS.md` — if project status changed (e.g., first feature started building)
 
 ---
 
@@ -103,7 +103,7 @@ Tell the calling skill what was written:
 - Only touch files that actually changed — do not rewrite unchanged files
 - `active_session.md` is ALWAYS updated — it is the checkpoint
 - `status.md` is the gate signal — planner reads this for auto-detection
-- Never write to `projects/<slug>/plan/` — that's planner territory
-- Never write to `projects/<slug>/design/` or `handoff/` — that's PD territory
+- Never write to `DDD/projects/<slug>/plan/` — that's planner territory
+- Never write to `DDD/projects/<slug>/design/` or `handoff/` — that's PD territory
 - Never write to `design-system/` — that's DS territory
 - If `dev/` directory doesn't exist, create it

--- a/skills/executor/SKILL.md
+++ b/skills/executor/SKILL.md
@@ -22,8 +22,8 @@ Orchestrate building features from execution bundles using specialized sub-agent
 ## Step 1 — Load context and check for in-progress session
 
 Read these files (skip gracefully if missing):
-- `projects/PROJECTS.md` — all projects
-- Find any `projects/*/dev/active_session.md` — in-progress build
+- `DDD/projects/PROJECTS.md` — all projects
+- Find any `DDD/projects/*/dev/active_session.md` — in-progress build
 
 **If `active_session.md` exists and has `status: in_progress` and `agent: executor`:**
 
@@ -80,7 +80,7 @@ Invoke exec-resume. It handles checkpoint loading internally.
 
 ### → Status display (inline)
 
-Read `projects/<slug>/dev/status.md`. Present:
+Read `DDD/projects/<slug>/dev/status.md`. Present:
 
 ```
 --------------------------------------------
@@ -109,7 +109,7 @@ If no `status.md` exists:
 - Never assume which project to work on if multiple exist — ask
 - Surface the next action at the end of every interaction
 - Never write code directly — always delegate to sub-agents
-- Never modify `projects/<slug>/plan/` — that's planner territory
-- Never modify `projects/<slug>/design/` or `handoff/` — that's PD territory
+- Never modify `DDD/projects/<slug>/plan/` — that's planner territory
+- Never modify `DDD/projects/<slug>/design/` or `handoff/` — that's PD territory
 - Never modify `design-system/` — that's DS territory
 - Read `plan/` and `handoff/` and `design-system/knowledge-base/` for context — but never write to them

--- a/skills/pd-annotate/SKILL.md
+++ b/skills/pd-annotate/SKILL.md
@@ -16,9 +16,9 @@ Add logic and behavior annotations to final designed screens. One annotation fra
 ## Step 1 — Load context
 
 Read:
-- `projects/<slug>/brief.md` — annotation preference (native or custom), if already set
-- `projects/<slug>/screen-inventory.md` — screens with status `designed`
-- `projects/<slug>/active_session.md`
+- `DDD/projects/<slug>/brief.md` — annotation preference (native or custom), if already set
+- `DDD/projects/<slug>/screen-inventory.md` — screens with status `designed`
+- `DDD/projects/<slug>/active_session.md`
 - `design-system/knowledge-base/components.md` — check if annotation component exists
 
 Update `active_session.md`:

--- a/skills/pd-concept/SKILL.md
+++ b/skills/pd-concept/SKILL.md
@@ -17,10 +17,10 @@ Explore design directions: 3 written concepts per item → user picks one → lo
 ## Step 1 — Load context
 
 Read:
-- `projects/<slug>/brief.md`
-- `projects/<slug>/flows.md`
-- `projects/<slug>/directions.md`
-- `projects/<slug>/active_session.md` — check for concept queue and last completed item
+- `DDD/projects/<slug>/brief.md`
+- `DDD/projects/<slug>/flows.md`
+- `DDD/projects/<slug>/directions.md`
+- `DDD/projects/<slug>/active_session.md` — check for concept queue and last completed item
 - `design-system/knowledge-base/components.md` — available components for reference
 - `design-system/knowledge-base/tokens.md` — tokens for lo-fi reference
 
@@ -159,7 +159,7 @@ If "Lock" → proceed to 3g.
 
 ### 3g — Lock direction and log
 
-Update `projects/<slug>/directions.md`:
+Update `DDD/projects/<slug>/directions.md`:
 ```
 | <Item> | Concept 1: <name>, Concept 2: <name>, Concept 3: <name> | <Chosen concept name> | <One line rationale> | <date> |
 ```

--- a/skills/pd-define/SKILL.md
+++ b/skills/pd-define/SKILL.md
@@ -16,9 +16,9 @@ Map user flows, information architecture, and build the screen inventory. The co
 ## Step 1 — Load context
 
 Read:
-- `projects/<slug>/brief.md`
-- `projects/<slug>/research.md` (if it exists)
-- `projects/<slug>/active_session.md`
+- `DDD/projects/<slug>/brief.md`
+- `DDD/projects/<slug>/research.md` (if it exists)
+- `DDD/projects/<slug>/active_session.md`
 
 If no active project → prompt to run `/pd:new-project`.
 
@@ -146,7 +146,7 @@ Save confirmed queue to `active_session.md`.
 
 ## Step 7 — Write flows.md and update screen-inventory.md
 
-**`projects/<slug>/flows.md`:**
+**`DDD/projects/<slug>/flows.md`:**
 ```markdown
 # Flows: <Project Name>
 

--- a/skills/pd-design/SKILL.md
+++ b/skills/pd-design/SKILL.md
@@ -16,12 +16,12 @@ Build final high-fidelity screens using the design system. The second diamond of
 ## Step 1 — Load context
 
 Read:
-- `projects/<slug>/brief.md`
-- `projects/<slug>/flows.md`
-- `projects/<slug>/directions.md` — locked directions per screen
-- `projects/<slug>/screen-inventory.md` — screens and their status
-- `projects/<slug>/component-gaps.md` — known gaps
-- `projects/<slug>/active_session.md`
+- `DDD/projects/<slug>/brief.md`
+- `DDD/projects/<slug>/flows.md`
+- `DDD/projects/<slug>/directions.md` — locked directions per screen
+- `DDD/projects/<slug>/screen-inventory.md` — screens and their status
+- `DDD/projects/<slug>/component-gaps.md` — known gaps
+- `DDD/projects/<slug>/active_session.md`
 - `design-system/knowledge-base/components.md`
 - `design-system/knowledge-base/tokens.md`
 - `design-system/knowledge-base/theming-conventions.md` (if exists)

--- a/skills/pd-discover/SKILL.md
+++ b/skills/pd-discover/SKILL.md
@@ -16,9 +16,9 @@ Research, ideation, and problem framing. The first diamond of Double Diamond.
 ## Step 1 — Load context
 
 Read:
-- `projects/<slug>/brief.md` — project brief
-- `projects/<slug>/active_session.md` — current phase and checkpoint
-- `projects/PROJECTS.md` — identify active project slug
+- `DDD/projects/<slug>/brief.md` — project brief
+- `DDD/projects/<slug>/active_session.md` — current phase and checkpoint
+- `DDD/projects/PROJECTS.md` — identify active project slug
 
 If no active project is found, tell the user:
 > "No active project found. Run `/pd:new-project` to start one."
@@ -98,7 +98,7 @@ If yes → ask for principles or suggest based on the challenge (e.g., "Progress
 
 ## Step 5 — Write research.md
 
-Write `projects/<slug>/research.md`:
+Write `DDD/projects/<slug>/research.md`:
 ```markdown
 # Research & Discovery: <Project Name>
 
@@ -144,7 +144,7 @@ Invoke pd-write-memory.
 ────────────────────────────────────────
 ✅  Discovery complete
 
-Research saved to projects/<slug>/research.md
+Research saved to DDD/projects/<slug>/research.md
 
 **What's next:** /pd:define — Map out user flows and build your screen inventory
 

--- a/skills/pd-gap-report/SKILL.md
+++ b/skills/pd-gap-report/SKILL.md
@@ -24,7 +24,7 @@ Log a missing component and coordinate resolution.
 
 ## Step 1 — Check if gap already logged
 
-Read `projects/<slug>/component-gaps.md`.
+Read `DDD/projects/<slug>/component-gaps.md`.
 If the component is already listed → update the `screens` column to include the new screen. Do not duplicate.
 
 ---

--- a/skills/pd-handoff/SKILL.md
+++ b/skills/pd-handoff/SKILL.md
@@ -16,12 +16,12 @@ Generate the development handoff: a Figma handoff page and a markdown spec docum
 ## Step 1 — Load context
 
 Read:
-- `projects/<slug>/brief.md`
-- `projects/<slug>/flows.md`
-- `projects/<slug>/screen-inventory.md`
-- `projects/<slug>/directions.md`
-- `projects/<slug>/component-gaps.md`
-- `projects/<slug>/active_session.md`
+- `DDD/projects/<slug>/brief.md`
+- `DDD/projects/<slug>/flows.md`
+- `DDD/projects/<slug>/screen-inventory.md`
+- `DDD/projects/<slug>/directions.md`
+- `DDD/projects/<slug>/component-gaps.md`
+- `DDD/projects/<slug>/active_session.md`
 - `design-system/knowledge-base/components.md`
 - `design-system/config.md`
 
@@ -67,7 +67,7 @@ Organize by flow: create a labeled section per flow on the handoff page.
 
 ## Step 3 — Generate markdown handoff document
 
-Write `projects/<slug>/handoff/<slug>-handoff.md`:
+Write `DDD/projects/<slug>/handoff/<slug>-handoff.md`:
 
 ```markdown
 # Development Handoff: <Project Name>
@@ -225,12 +225,12 @@ Update `active_session.md`:
 ```markdown
 ### Handoff
 status: complete
-handoff_doc: projects/<slug>/handoff/<slug>-handoff.md
+handoff_doc: DDD/projects/<slug>/handoff/<slug>-handoff.md
 figma_page: PDA — <Project Name> — Handoff
 screens_handed_off: <n>
 ```
 
-Update `projects/PROJECTS.md` — set project status to `handoff-complete`.
+Update `DDD/projects/PROJECTS.md` — set project status to `handoff-complete`.
 
 Invoke pd-write-memory.
 
@@ -242,7 +242,7 @@ Invoke pd-write-memory.
 ────────────────────────────────────────
 ✅  Handoff complete: <Project Name>
 
-📄  Spec doc:   projects/<slug>/handoff/<slug>-handoff.md
+📄  Spec doc:   DDD/projects/<slug>/handoff/<slug>-handoff.md
 🎨  Figma page: PDA — <Project Name> — Handoff
 
 <n> screens · <n> flows · <n> components documented

--- a/skills/pd-handoff/SKILL.md
+++ b/skills/pd-handoff/SKILL.md
@@ -199,11 +199,25 @@ Write `DDD/projects/<slug>/handoff/<slug>-handoff.md`:
 
 ---
 
+## Step 3b — Spawn task-verifier
+
+After writing the handoff markdown document, spawn task-verifier as a subagent with:
+- `artifact_type`: `handoff`
+- `artifact_paths`: `DDD/projects/<slug>/handoff/<slug>-handoff.md`
+- `criteria`: the annotated screens and must-haves from the design phase
+- `context_paths`: `DDD/projects/<slug>/design/` (concept and define docs), `DDD/projects/<slug>/brief.md`
+
+If BLOCK → fix the flagged gaps in the handoff doc before showing it to the user.
+If WARN → surface warnings in the Step 4 review so the user can decide whether to address them.
+
+---
+
 ## Step 4 — Review with user
 
 Present:
 - Screenshot of Figma handoff page
 - Summary of what was written to the markdown doc
+- Any task-verifier warnings (if WARN)
 
 Ask:
 ```

--- a/skills/pd-new-project/SKILL.md
+++ b/skills/pd-new-project/SKILL.md
@@ -15,7 +15,7 @@ Initialize a product design project: ingest or write a brief, create project mem
 
 ## Step 1 — Load context
 
-Read `projects/PROJECTS.md` if it exists. Note any existing projects.
+Read `DDD/projects/PROJECTS.md` if it exists. Note any existing projects.
 
 ---
 
@@ -104,7 +104,7 @@ Slugify the name: lowercase, hyphens, no spaces. E.g., `donor-portal`, `checkout
 
 Create the following files:
 
-**`projects/<slug>/brief.md`**
+**`DDD/projects/<slug>/brief.md`**
 ```markdown
 # Project Brief: <Project Name>
 
@@ -142,7 +142,7 @@ pending
 <original source URL or "written in session">
 ```
 
-**`projects/<slug>/screen-inventory.md`**
+**`DDD/projects/<slug>/screen-inventory.md`**
 ```markdown
 # Screen Inventory: <Project Name>
 
@@ -152,7 +152,7 @@ pending
 |--------|------|----------|--------|------------|-------|
 ```
 
-**`projects/<slug>/component-gaps.md`**
+**`DDD/projects/<slug>/component-gaps.md`**
 ```markdown
 # Component Gaps: <Project Name>
 
@@ -163,7 +163,7 @@ pending
 |-----------|--------|-------------------|--------|------|
 ```
 
-**`projects/<slug>/directions.md`**
+**`DDD/projects/<slug>/directions.md`**
 ```markdown
 # Directions: <Project Name>
 
@@ -173,7 +173,7 @@ pending
 |------|-------------------|------------------|-----------|------|
 ```
 
-**`projects/<slug>/active_session.md`**
+**`DDD/projects/<slug>/active_session.md`**
 ```markdown
 # Active Session
 
@@ -191,7 +191,7 @@ status: complete
 brief_source: <source>
 ```
 
-Update `projects/PROJECTS.md`:
+Update `DDD/projects/PROJECTS.md`:
 - Add row: `| <Project Name> | <slug> | DISCOVER | in_progress | <date> |`
 
 ---
@@ -202,7 +202,7 @@ Update `projects/PROJECTS.md`:
 ────────────────────────────────────────
 ✅  Project initialized: <Project Name>
 
-Brief saved to projects/<slug>/brief.md
+Brief saved to DDD/projects/<slug>/brief.md
 
 **What's next:** /pd:discover — Research, ideation, and problem framing
 

--- a/skills/pd-resume/SKILL.md
+++ b/skills/pd-resume/SKILL.md
@@ -14,7 +14,7 @@ Restore project context from memory and continue from the last checkpoint.
 
 ## Step 1 — Load checkpoint
 
-Read `projects/<slug>/active_session.md`.
+Read `DDD/projects/<slug>/active_session.md`.
 
 If no `active_session.md` exists or `status: complete` → tell user:
 > "No in-progress session found. Use `/pd:status` to see your projects or `/pd:new-project` to start one."

--- a/skills/pd-resume/SKILL.md
+++ b/skills/pd-resume/SKILL.md
@@ -14,10 +14,74 @@ Restore project context from memory and continue from the last checkpoint.
 
 ## Step 1 — Load checkpoint
 
-Read `DDD/projects/<slug>/active_session.md`.
+Read `DDD/projects/PROJECTS.md`. Find sessions: look for `DDD/projects/*/design/active_session.md`.
 
-If no `active_session.md` exists or `status: complete` → tell user:
-> "No in-progress session found. Use `/pd:status` to see your projects or `/pd:new-project` to start one."
+**Case A — In-progress session found** (status: in_progress) → continue to Step 2.
+
+**Case B — No session or all complete** → continue to Step 1b.
+
+If multiple in-progress sessions → ask which one to resume.
+
+---
+
+## Step 1b — Intelligent next step detection
+
+No active design session. Scan all active projects to find what needs the product designer next.
+
+For each project in PROJECTS.md, read in parallel:
+- `DDD/projects/<slug>/plan/master-plan.md`
+- List files in `DDD/projects/<slug>/design/`
+- List files in `DDD/projects/<slug>/handoff/`
+
+Then identify what phase each feature needs:
+
+**Needs DISCOVER or DEFINE** — feature in master-plan.md tagged `needs-design` with no files in `design/` yet. Not started.
+
+**Needs CONCEPT** — brief/define doc exists in `design/` but no concept doc. Start concepting.
+
+**Needs DESIGN (hi-fi)** — concept is locked (`design/<feature>-concept.md` exists, direction chosen) but no Figma screens yet.
+
+**Needs ANNOTATE** — Figma screens exist but no annotation doc in `design/`.
+
+**Needs HANDOFF** — annotated screens exist but no `handoff/<feature>-handoff.md` yet. Blocking the executor.
+
+**Already handed off** — `handoff/<feature>-handoff.md` exists. No action needed from designer.
+
+Present:
+
+```
+────────────────────────────────────────────
+  No active design session. Here's what needs the designer:
+
+  NEEDS HANDOFF (blocking executor):
+  • <project> / <feature> — annotated, handoff not done yet
+
+  NEEDS ANNOTATION:
+  • <project> / <feature> — screens done, not annotated
+
+  NEEDS DESIGN (hi-fi):
+  • <project> / <feature> — concept locked, no screens yet
+
+  NEEDS CONCEPT:
+  • <project> / <feature> — define done, not concepted
+
+  NOT STARTED:
+  • <project> / <feature> — needs-design, no work begun
+────────────────────────────────────────────
+```
+
+Use AskUserQuestion:
+```
+question: "What would you like to work on?"
+options:
+  - "Handoff <top blocking feature>"
+  - "Annotate <next annotation feature>"
+  - "Design <next hi-fi feature>"
+  - "Start a new feature from scratch"
+  - "Show full design status — /pd:status"
+```
+
+If user picks a feature → invoke the appropriate phase skill for it. Do NOT stall.
 
 ---
 
@@ -64,6 +128,8 @@ Pass the checkpoint context (current item, queue state, figma page) so the phase
 
 ## Rules
 
+- **Never stall** — if no active session, scan the project state and surface what phase each feature needs next
 - Never restart a phase from scratch on resume — always skip to the last incomplete step
+- Prioritize handoff gaps — a feature blocked on handoff is blocking the entire executor pipeline
 - If the checkpoint references a Figma node that no longer exists → warn and ask user to re-identify the node
 - If multiple projects are in-progress → ask which one to resume before loading checkpoint

--- a/skills/pd-status/SKILL.md
+++ b/skills/pd-status/SKILL.md
@@ -14,7 +14,7 @@ Show a full project overview: phase, screen inventory, gaps, and what's next.
 
 ## Step 1 — Identify active project
 
-Read `projects/PROJECTS.md`.
+Read `DDD/projects/PROJECTS.md`.
 
 If one project with `status: in_progress` → use it.
 If multiple in-progress projects → ask:
@@ -33,11 +33,11 @@ If no active project → show PROJECTS.md summary and suggest `/pd:new-project`.
 ## Step 2 — Load project files
 
 Read:
-- `projects/<slug>/brief.md`
-- `projects/<slug>/screen-inventory.md`
-- `projects/<slug>/component-gaps.md`
-- `projects/<slug>/active_session.md`
-- `projects/<slug>/directions.md`
+- `DDD/projects/<slug>/brief.md`
+- `DDD/projects/<slug>/screen-inventory.md`
+- `DDD/projects/<slug>/component-gaps.md`
+- `DDD/projects/<slug>/active_session.md`
+- `DDD/projects/<slug>/directions.md`
 
 ---
 

--- a/skills/pd-write-memory/SKILL.md
+++ b/skills/pd-write-memory/SKILL.md
@@ -16,13 +16,13 @@ Persist session changes to product design project memory files.
 
 Review the current session's actions. Identify which files need updating:
 
-- `projects/<slug>/screen-inventory.md` — if screens were added, designed, or annotated
-- `projects/<slug>/component-gaps.md` — if gaps were logged or resolved
-- `projects/<slug>/directions.md` — if a concept direction was locked
-- `projects/<slug>/flows.md` — if flows were defined or updated
-- `projects/<slug>/research.md` — if discovery content was written
-- `projects/<slug>/active_session.md` — always updated with current phase and checkpoint
-- `projects/PROJECTS.md` — if project phase changed
+- `DDD/projects/<slug>/screen-inventory.md` — if screens were added, designed, or annotated
+- `DDD/projects/<slug>/component-gaps.md` — if gaps were logged or resolved
+- `DDD/projects/<slug>/directions.md` — if a concept direction was locked
+- `DDD/projects/<slug>/flows.md` — if flows were defined or updated
+- `DDD/projects/<slug>/research.md` — if discovery content was written
+- `DDD/projects/<slug>/active_session.md` — always updated with current phase and checkpoint
+- `DDD/projects/PROJECTS.md` — if project phase changed
 
 ---
 

--- a/skills/plan-feature/SKILL.md
+++ b/skills/plan-feature/SKILL.md
@@ -134,6 +134,16 @@ Wave 3: <tasks after design handoff — awaiting>
 
 Write `DDD/projects/<slug>/plan/features/<feature-slug>.md` with Pass 1 content.
 Update master-plan.md feature status.
+
+**Spawn task-verifier** with:
+- `artifact_type`: `bundle`
+- `artifact_paths`: the feature file just written
+- `criteria`: the feature description and must-haves from master-plan.md
+- `context_paths`: `DDD/projects/<slug>/brief.md`
+
+If BLOCK → fix the flagged gaps before invoking plan-write-memory or presenting to the user.
+If WARN → surface warnings in the output summary.
+
 Invoke plan-write-memory.
 
 Present:
@@ -284,6 +294,16 @@ Update the feature plan header:
 ```
 
 Update master-plan.md feature and gate status.
+
+**Spawn task-verifier** with:
+- `artifact_type`: `bundle`
+- `artifact_paths`: the feature file just written
+- `criteria`: the acceptance criteria and must-haves from the bundle itself
+- `context_paths`: the design handoff doc, `DDD/projects/<slug>/brief.md`
+
+If BLOCK → fix the flagged gaps before marking `ready-for-execution` or invoking plan-write-memory.
+If WARN → surface warnings in the output summary.
+
 Invoke plan-write-memory.
 
 Present:

--- a/skills/plan-feature/SKILL.md
+++ b/skills/plan-feature/SKILL.md
@@ -20,7 +20,7 @@ Detail a specific feature into a self-contained execution bundle with tasks, des
 ## Step 1 — Load context
 
 Read:
-- `projects/<slug>/plan/master-plan.md`
+- `DDD/projects/<slug>/plan/master-plan.md`
 - If no master plan → "Run `/plan:project` first to create a master plan."
 
 ---
@@ -36,7 +36,7 @@ options:
   - "<feature 3>"
 ```
 
-Check if this feature has been planned before by looking for `projects/<slug>/plan/features/<feature-slug>.md`.
+Check if this feature has been planned before by looking for `DDD/projects/<slug>/plan/features/<feature-slug>.md`.
 
 ---
 
@@ -48,7 +48,7 @@ Check the feature's workstream tags from master-plan.md:
 → Single pass. Plan everything now. Skip to Step 4a.
 
 **If feature HAS `needs-design` tasks:**
-→ Check if handoff doc exists at `projects/<slug>/handoff/<feature-slug>-handoff.md`
+→ Check if handoff doc exists at `DDD/projects/<slug>/handoff/<feature-slug>-handoff.md`
   - **No handoff doc** → **Pass 1** (plan backend, define design scope)
   - **Handoff doc exists** → **Pass 2** (read handoff, complete the bundle)
 
@@ -107,7 +107,7 @@ Re-run `/plan:feature <feature>` after design delivers to complete Pass 2.
 - Gate: <gate name from master-plan.md>
 - Criteria:
   - [ ] Figma screens finalized and annotated
-  - [ ] pd-handoff doc produced at projects/<slug>/handoff/<feature>-handoff.md
+  - [ ] pd-handoff doc produced at DDD/projects/<slug>/handoff/<feature>-handoff.md
   - [ ] Component gaps resolved or documented
 ```
 
@@ -132,7 +132,7 @@ Wave 3: <tasks after design handoff — awaiting>
 
 ### Save and delegate
 
-Write `projects/<slug>/plan/features/<feature-slug>.md` with Pass 1 content.
+Write `DDD/projects/<slug>/plan/features/<feature-slug>.md` with Pass 1 content.
 Update master-plan.md feature status.
 Invoke plan-write-memory.
 
@@ -159,8 +159,8 @@ Open decisions:
 
 ## Step 4b — Pass 2: Complete the execution bundle
 
-Read the pd-handoff doc at `projects/<slug>/handoff/<feature-slug>-handoff.md`.
-Also read `projects/<slug>/design/component-gaps.md` for DS gap status.
+Read the pd-handoff doc at `DDD/projects/<slug>/handoff/<feature-slug>-handoff.md`.
+Also read `DDD/projects/<slug>/design/component-gaps.md` for DS gap status.
 
 ### Inline design context
 

--- a/skills/plan-project/SKILL.md
+++ b/skills/plan-project/SKILL.md
@@ -262,6 +262,19 @@ Write `DDD/projects/<slug>/plan/master-plan.md`:
 
 ---
 
+## Step 10b — Spawn task-verifier
+
+After writing master-plan.md, spawn task-verifier as a subagent with:
+- `artifact_type`: `plan`
+- `artifact_paths`: the master-plan.md just written
+- `criteria`: the feature list confirmed in Step 4 and must-haves from Step 9
+- `context_paths`: `DDD/projects/<slug>/brief.md`
+
+If BLOCK → fix the flagged gaps in the master plan before initializing project files.
+If WARN → surface warnings in the Step 13 output summary.
+
+---
+
 ## Step 11 — Initialize project files
 
 Create:

--- a/skills/plan-project/SKILL.md
+++ b/skills/plan-project/SKILL.md
@@ -19,8 +19,8 @@ Take a product brief and produce a phased master plan with features, gates, and 
 
 ## Step 1 — Load context
 
-Read `projects/PROJECTS.md` if it exists. Note any existing projects.
-If replanning an existing project, read `projects/<slug>/plan/master-plan.md`.
+Read `DDD/projects/PROJECTS.md` if it exists. Note any existing projects.
+If replanning an existing project, read `DDD/projects/<slug>/plan/master-plan.md`.
 
 ---
 
@@ -164,7 +164,7 @@ For every feature that spans workstreams, define gates:
 - **Feature:** Login flow
 - **Blocked work:** Login UI build (eng-frontend)
 - **Parallel work:** Auth API, middleware (eng-backend)
-- **Handoff input:** projects/<slug>/handoff/auth-login-handoff.md
+- **Handoff input:** DDD/projects/<slug>/handoff/auth-login-handoff.md
 - **Gate criteria:**
   - [ ] Figma screens finalized and annotated
   - [ ] pd-handoff doc produced
@@ -197,7 +197,7 @@ Validate that the features and their tasks cover all must-haves. Flag any gap.
 
 ## Step 10 — Generate master plan
 
-Write `projects/<slug>/plan/master-plan.md`:
+Write `DDD/projects/<slug>/plan/master-plan.md`:
 
 ```markdown
 # Master Plan: <Project Name>
@@ -250,7 +250,7 @@ Write `projects/<slug>/plan/master-plan.md`:
 - **Feature:** <feature>
 - **Blocked:** <feature list>
 - **Parallel:** <feature list>
-- **Handoff input:** projects/<slug>/handoff/<feature>-handoff.md
+- **Handoff input:** DDD/projects/<slug>/handoff/<feature>-handoff.md
 - **Criteria:**
   - [ ] <criterion>
 - **Status:** pending
@@ -266,9 +266,9 @@ Write `projects/<slug>/plan/master-plan.md`:
 
 Create:
 
-**`projects/<slug>/brief.md`** — the compiled brief (if not already existing from pd-new-project)
+**`DDD/projects/<slug>/brief.md`** — the compiled brief (if not already existing from pd-new-project)
 
-**`projects/<slug>/plan/active_session.md`**
+**`DDD/projects/<slug>/plan/active_session.md`**
 ```markdown
 # Active Session
 
@@ -282,7 +282,7 @@ session_started: <date>
 - Master plan created with <n> phases, <n> features, <n> gates
 ```
 
-Update `projects/PROJECTS.md`:
+Update `DDD/projects/PROJECTS.md`:
 - Add row: `| <Project Name> | <slug> | planning | active | <date> |`
 
 ---

--- a/skills/plan-resume/SKILL.md
+++ b/skills/plan-resume/SKILL.md
@@ -18,7 +18,7 @@ Restore planning context from checkpoint and continue from the last step.
 
 ## Step 1 — Load checkpoint
 
-Find active sessions: look for `projects/*/plan/active_session.md`.
+Find active sessions: look for `DDD/projects/*/plan/active_session.md`.
 
 If no `active_session.md` exists or all have `status: complete` → tell user:
 > "No in-progress planning session found. Use `/plan:status` to see your projects or `/plan:project` to start one."

--- a/skills/plan-resume/SKILL.md
+++ b/skills/plan-resume/SKILL.md
@@ -18,12 +18,68 @@ Restore planning context from checkpoint and continue from the last step.
 
 ## Step 1 — Load checkpoint
 
-Find active sessions: look for `DDD/projects/*/plan/active_session.md`.
+Read `DDD/projects/PROJECTS.md`. Find active sessions: look for `DDD/projects/*/plan/active_session.md`.
 
-If no `active_session.md` exists or all have `status: complete` → tell user:
-> "No in-progress planning session found. Use `/plan:status` to see your projects or `/plan:project` to start one."
+**Case A — In-progress session found** (status: in_progress) → continue to Step 2.
 
-If multiple projects have in-progress sessions → ask which one to resume.
+**Case B — No session or all complete** → continue to Step 1b.
+
+If multiple in-progress sessions → ask which one to resume.
+
+---
+
+## Step 1b — Intelligent next step detection
+
+No active planning session. Scan all active projects to surface what the planner should do next.
+
+For each project in PROJECTS.md, read in parallel:
+- `DDD/projects/<slug>/plan/master-plan.md`
+- List files in `DDD/projects/<slug>/handoff/`
+- List files in `DDD/projects/<slug>/plan/features/`
+- `DDD/projects/<slug>/dev/status.md` (if exists)
+
+Then identify:
+
+**Needs Pass 2 (bundle it)** — `handoff/<feature>-handoff.md` exists but `plan/features/<feature>.md` does not. Design is done; this feature is ready to be turned into an execution bundle.
+
+**Needs Pass 1 (detail it)** — feature appears in master-plan.md as `pending` with no feature file yet. Not yet detailed enough to build.
+
+**Already planned, not started** — feature file exists with `status: ready-for-execution` and doesn't appear in `dev/status.md`. Ready for the executor.
+
+**Blocked on open decisions** — features in master-plan.md tagged `product-decision` with status `pending`.
+
+Present:
+
+```
+────────────────────────────────────────────
+  No active planning session. Here's what needs the planner:
+
+  NEEDS PASS 2 (design done — bundle for executor):
+  • <project> / <feature> — handoff exists, no execution bundle yet
+    → /plan:feature <feature>
+
+  NEEDS PASS 1 (not yet detailed):
+  • <project> / <feature> — in master plan, no feature file
+
+  READY FOR EXECUTOR (already planned):
+  • <project> / <feature> — execution bundle exists
+
+  BLOCKED ON DECISIONS:
+  • <project> / <feature> — waiting on: <decision>
+────────────────────────────────────────────
+```
+
+Use AskUserQuestion:
+```
+question: "What would you like to plan?"
+options:
+  - "Bundle <top Pass 2 feature> for the executor"
+  - "Detail <top Pass 1 feature>"
+  - "Show full plan status — /plan:status"
+  - "Start a new project"
+```
+
+If user picks a feature → invoke plan-feature for it. Do NOT stall.
 
 ---
 
@@ -69,6 +125,7 @@ If "Jump to different skill" → ask which, then route.
 
 ## Rules
 
+- **Never stall** — if no active session, scan the plan and surface the next planning action
 - Never restart a skill from scratch on resume — skip to the last incomplete step
 - If multiple projects have active sessions → ask which one before loading
 - If the checkpoint references a feature that no longer exists in master-plan.md → warn and ask user

--- a/skills/plan-status/SKILL.md
+++ b/skills/plan-status/SKILL.md
@@ -18,7 +18,7 @@ Show a full project plan overview: phase progress, gate status, blockers, and wh
 
 ## Step 1 — Identify active project
 
-Read `projects/PROJECTS.md`.
+Read `DDD/projects/PROJECTS.md`.
 
 If one project with `status: active` → use it.
 If multiple active projects → ask:
@@ -37,10 +37,10 @@ If no active project → show PROJECTS.md and suggest `/plan:project`.
 ## Step 2 — Load project files
 
 Read:
-- `projects/<slug>/plan/master-plan.md`
-- All `projects/<slug>/plan/features/*.md`
-- `projects/<slug>/design/component-gaps.md` (if exists)
-- `projects/<slug>/dev/status.md` (if exists)
+- `DDD/projects/<slug>/plan/master-plan.md`
+- All `DDD/projects/<slug>/plan/features/*.md`
+- `DDD/projects/<slug>/design/component-gaps.md` (if exists)
+- `DDD/projects/<slug>/dev/status.md` (if exists)
 
 If Jira is configured in master-plan.md → query ticket statuses via Rovo MCP:
 ```
@@ -55,7 +55,7 @@ For each gate in master-plan.md:
 
 | Gate type | Check | Status |
 |---|---|---|
-| design → eng-frontend | `projects/<slug>/handoff/<feature>-handoff.md` exists? | pending → ready |
+| design → eng-frontend | `DDD/projects/<slug>/handoff/<feature>-handoff.md` exists? | pending → ready |
 | design-system gap | `design/component-gaps.md` — all gaps for this feature resolved? | pending → ready |
 | product decision | Decision marked in feature plan? | pending → decided |
 | eng-backend → eng-frontend | `dev/status.md` shows backend stage complete for this feature? | pending → ready |

--- a/skills/plan-write-memory/SKILL.md
+++ b/skills/plan-write-memory/SKILL.md
@@ -18,10 +18,10 @@ Persist session changes to project plan files.
 
 Review the current session's actions. Identify which files need updating:
 
-- `projects/<slug>/plan/master-plan.md` — if phases, features, or gates were added/updated
-- `projects/<slug>/plan/features/<feature>.md` — if a feature was planned (Pass 1 or Pass 2)
-- `projects/<slug>/plan/active_session.md` — always updated with current skill and checkpoint
-- `projects/PROJECTS.md` — if project status or phase changed
+- `DDD/projects/<slug>/plan/master-plan.md` — if phases, features, or gates were added/updated
+- `DDD/projects/<slug>/plan/features/<feature>.md` — if a feature was planned (Pass 1 or Pass 2)
+- `DDD/projects/<slug>/plan/active_session.md` — always updated with current skill and checkpoint
+- `DDD/projects/PROJECTS.md` — if project status or phase changed
 
 ---
 
@@ -82,8 +82,8 @@ Tell the calling skill what was written:
 
 - Only touch files that actually changed — do not rewrite unchanged files
 - `active_session.md` is ALWAYS updated — it is the checkpoint
-- Never write to `projects/<slug>/design/` — that's PD territory
-- Never write to `projects/<slug>/handoff/` — that's PD output
-- Never write to `projects/<slug>/dev/` — that's executor territory
+- Never write to `DDD/projects/<slug>/design/` — that's PD territory
+- Never write to `DDD/projects/<slug>/handoff/` — that's PD output
+- Never write to `DDD/projects/<slug>/dev/` — that's executor territory
 - Never write to `design-system/` — that's DS territory
 - PROJECTS.md status is updated every session end

--- a/skills/planner/SKILL.md
+++ b/skills/planner/SKILL.md
@@ -21,8 +21,8 @@ Independent orchestrator for end-to-end product development: from brief to phase
 ## Step 1 — Load context and check for in-progress session
 
 Read these files (skip gracefully if missing):
-- `projects/PROJECTS.md` — all projects and their current phase
-- Find any `projects/*/plan/active_session.md` — in-progress planning checkpoint
+- `DDD/projects/PROJECTS.md` — all projects and their current phase
+- Find any `DDD/projects/*/plan/active_session.md` — in-progress planning checkpoint
 
 **If `active_session.md` exists and has `status: in_progress` and `agent: planner`:**
 
@@ -78,8 +78,8 @@ options:
 - Always check for `active_session.md` before starting any new work
 - Never assume which project to work on if multiple exist — ask
 - Surface the delegation output at the end of every skill (what to do next and which agent)
-- All project plan memory lives under `projects/<project-slug>/plan/`
-- Never modify `projects/<slug>/design/` — that's PD territory
-- Never modify `projects/<slug>/handoff/` — that's PD output
+- All project plan memory lives under `DDD/projects/<project-slug>/plan/`
+- Never modify `DDD/projects/<slug>/design/` — that's PD territory
+- Never modify `DDD/projects/<slug>/handoff/` — that's PD output
 - Never modify `design-system/` — that's DS territory
 - Read `handoff/` and `design/component-gaps.md` for gate detection and Pass 2 — but never write to them

--- a/skills/product-design-help/SKILL.md
+++ b/skills/product-design-help/SKILL.md
@@ -14,7 +14,7 @@ Explain the Product Designer Agent: what it does, the design phases, and when to
 ## Procedure
 
 ### Step 1 — Load state
-Read `projects/PROJECTS.md` (skip if missing) to check for active projects.
+Read `DDD/projects/PROJECTS.md` (skip if missing) to check for active projects.
 
 ### Step 2 — Present explanation
 
@@ -64,7 +64,7 @@ Each project moves through sequential phases. You can jump to any phase directly
 - Each phase ends with a checkpoint saved to `design-system/memory/active_session.md`.
 - Running `/product-designer` after a break detects the checkpoint and offers to resume.
 - If context gets too long (>60% usage), the agent warns you — `/clear` then `/product-designer` to resume safely.
-- All project files live in `projects/<project-slug>/`.
+- All project files live in `DDD/projects/<project-slug>/`.
 
 ---
 
@@ -82,6 +82,6 @@ Each project moves through sequential phases. You can jump to any phase directly
 ```
 
 ## Rules
-- Fill in active projects from `projects/PROJECTS.md` if it exists
+- Fill in active projects from `DDD/projects/PROJECTS.md` if it exists
 - If the file is missing or empty, show the "No projects yet" message
 - Keep output scannable — tables as presented, no extra prose

--- a/skills/product-designer/SKILL.md
+++ b/skills/product-designer/SKILL.md
@@ -18,7 +18,7 @@ Unified agent for end-to-end product design: from brief to fully designed, annot
 ## Step 1 — Load context and check for in-progress session
 
 Read these files (skip gracefully if missing):
-- `projects/PROJECTS.md` — all projects and their current phase
+- `DDD/projects/PROJECTS.md` — all projects and their current phase
 - `design-system/memory/active_session.md` — in-progress checkpoint
 
 **If `active_session.md` exists and has `status: in_progress` and `agent: product-designer`:**
@@ -83,5 +83,5 @@ options:
 - Never assume which project to work on if multiple exist — ask
 - Surface the "What's next" footer at the end of every phase
 - If context usage is above 60% → warn: "Context is getting full. Your work is checkpointed — you can `/clear` and run `/product-designer` to resume."
-- All project memory lives under `projects/<project-slug>/`
+- All project memory lives under `DDD/projects/<project-slug>/`
 - Never modify `design-system/knowledge-base/` unless a component gap was resolved via ds-plan/ds-build

--- a/skills/task-verifier/SKILL.md
+++ b/skills/task-verifier/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: task-verifier
+model: sonnet
+effort: low
+description: >
+  Lightweight reasoning verifier. Spawned as a subagent after an artifact is produced
+  to catch gaps and mistakes before they propagate. Reads with fresh eyes — no inherited
+  context from the producing agent. Not a compliance audit; focuses on logic, coverage,
+  and obvious quality gaps. Returns PASS, WARN, or BLOCK.
+  Called by exec-backend, exec-frontend, plan-feature, plan-project, pd-handoff.
+  Never invoked directly by the user.
+---
+
+# Task Verifier
+
+Read what was just produced and check whether it actually does the job. Fresh eyes only.
+
+**Effort level: low.** Fast, focused, proportionate. Don't nitpick — catch real gaps.
+
+---
+
+## Inputs
+
+- `artifact_type` — `code` | `plan` | `bundle` | `handoff`
+- `artifact_paths` — files to read
+- `criteria` — what it must satisfy (acceptance criteria, must-haves, brief, task description)
+- `context_paths` — supporting files for comparison (feature bundle, architecture.md, handoff, etc.)
+
+---
+
+## Step 1 — Read artifact and criteria fresh
+
+Read every file in `artifact_paths` and `context_paths`. Do not assume anything was done correctly — verify against the criteria directly.
+
+---
+
+## Step 2 — Apply three core questions
+
+For any artifact type, always ask:
+
+1. **Does it cover what was asked?**
+   Is anything in the criteria missing from the artifact? Look for gaps — things that were specified but not addressed.
+
+2. **Does it make sense on its own?**
+   Are there internal contradictions, broken references, or logic that doesn't hold up? (Dependencies that don't exist, conditions that can never be true, steps out of order.)
+
+3. **Will the next person get stuck?**
+   If a developer reads this plan, or another agent reads this code, will they have what they need? Flag anything that would cause a handoff problem downstream.
+
+---
+
+## Step 3 — Apply one artifact-specific check
+
+### `code`
+- Does the code actually satisfy each acceptance criterion? Read each criterion and find the line of code that satisfies it. If you can't find it, flag it.
+- Does the happy path work? Does an obvious error case fail silently?
+
+### `plan` (master plan)
+- Does every feature in the plan trace back to a capability in the brief? Is anything missing from the brief, or invented?
+- Are the phase dependencies directionally correct (no phase depending on a later phase)?
+
+### `bundle` (execution bundle)
+- Does every frontend task have a corresponding backend task, or is there an assumption that the API already exists?
+- Does every acceptance criterion use verifiable language ("returns 401", "shows error state") rather than vague language ("handles errors correctly", "works")?
+
+### `handoff`
+- Does every screen have its states defined (default, error, empty)? A screen without states will block the developer.
+- Is there a component map? Without it, the executor can't run Stage 1 (DS gaps).
+
+---
+
+## Step 4 — Return verdict
+
+Keep it short. If nothing is wrong, say so in one line.
+
+```markdown
+## Verification: <artifact name>
+
+**Verdict:** PASS | WARN | BLOCK
+
+**Issues:**
+- [BLOCK] <file or section> — <what is missing or wrong> — <why it matters>
+- [WARN]  <file or section> — <what should be fixed>
+
+**Passed:** <brief statement of what was confirmed correct>
+```
+
+**Verdict rules:**
+- **BLOCK** — any issue that will cause the next step to fail or produce wrong output. The calling skill must fix before proceeding.
+- **WARN** — something worth fixing but won't break the next step. Calling skill can surface at next checkpoint.
+- **PASS** — no issues, or only very minor observations not worth flagging.
+
+If PASS: one line is enough: `Verification PASS — criteria met, no gaps found.`
+
+---
+
+## Rules
+
+- **Read the actual files** — don't reason from the producing agent's summary of what it did
+- **Criteria are the source of truth** — only flag gaps against what was asked, not general best practices
+- **One issue per bullet** — no bundling
+- **Proportionate severity** — a missing auth check is BLOCK; a slightly vague comment is not worth flagging at all
+- **Don't re-run tooling** — exec-verifier handles linting and type checks; this skill handles reasoning
+- **If in doubt, WARN not BLOCK** — only BLOCK when you are confident the next step will fail

--- a/skills/task-verifier/SKILL.md
+++ b/skills/task-verifier/SKILL.md
@@ -21,7 +21,7 @@ Read what was just produced and check whether it actually does the job. Fresh ey
 
 ## Inputs
 
-- `artifact_type` — `code` | `plan` | `bundle` | `handoff`
+- `artifact_type` — `code` | `plan` | `bundle` | `handoff` | `architecture`
 - `artifact_paths` — files to read
 - `criteria` — what it must satisfy (acceptance criteria, must-haves, brief, task description)
 - `context_paths` — supporting files for comparison (feature bundle, architecture.md, handoff, etc.)
@@ -66,6 +66,12 @@ For any artifact type, always ask:
 ### `handoff`
 - Does every screen have its states defined (default, error, empty)? A screen without states will block the developer.
 - Is there a component map? Without it, the executor can't run Stage 1 (DS gaps).
+
+### `architecture`
+- Does every task in the feature bundle have a corresponding architecture block? Any task without one will be built without guidance.
+- Do the execution waves respect the stated dependencies — is any task scheduled in a wave before its dependency completes?
+- Does every pattern reference cite a real existing file? A reference to a file that doesn't exist will mislead exec-backend or exec-frontend.
+- Does the data flow for each task match what the feature bundle actually requires? Flag any mismatch between what the bundle asks for and what the architect decided.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Restructure**: Moved `projects/` → `DDD/projects/` across all 26 skills and `CLAUDE.md` so all DDD orchestration files live under `DDD/`
- **Doc generation**: `exec-backend` now writes project docs to `DDD/projects/<slug>/docs/` after code changes; `exec-architect` tags tasks with a Docs Impact block to signal which docs need updating
- **Smarter resume**: `exec-resume` no longer stalls when no active session exists — scans the plan, detects gate unblocks, surfaces partially built features, and suggests the next action
- **ds-update pagination fix**: replaced `figma_get_variables` (paginates silently) with `figma_execute` (fetches all variables in one call), added a coverage check that aborts on incomplete scans, and expanded diff to three-way Added/Removed/Changed at group and token level

## Issues closed
- Closes #13 — Docs not generated / wrong placement
- Closes #14 — exec-resume should be smarter
- Closes #6 — ds-update misses tokens outside first paginated batch

## Test plan
- [ ] Verify `DDD/projects/` path resolves correctly when running any planner or executor skill
- [ ] Run `exec-backend` on a task with a DB change — confirm `docs/DATABASE.md` is created in `DDD/projects/<slug>/docs/`
- [ ] Run `/exec:resume` with no active session — confirm it surfaces plan state instead of stalling
- [ ] Run `/ds-update` on a Figma file with >50 variables — confirm all variables fetched and diff shows Added/Removed/Changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)